### PR TITLE
이메일 인증로직 수정

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/email/domain/entity/EmailCertificate.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/domain/entity/EmailCertificate.kt
@@ -8,15 +8,30 @@ import javax.persistence.*
 @Entity
 @Table(name = "Email_Certificate")
 class EmailCertificate(
+    @Column(name = "certificate_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    val id: Long,
     @Column(name = "certificate_email", nullable = false)
     val email: String,
     @Column(name = "certificate_key", nullable = false)
     val key: String,
     @Column(name = "certificate_expiredTime", nullable = false)
-    val expiredTime: LocalDateTime
+    val expiredTime: LocalDateTime,
+    @Column(name = "certificate_authentication", nullable = false)
+    val authentication: Boolean
 ) : BaseTimeEntity(){
-    @Column(name = "certificate_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Id
-    val id: Long = 0
+
+    constructor(email: String, key: String, expiredTime: LocalDateTime, authentication: Boolean)
+            :this(0, email, key, expiredTime, authentication)
+
+    fun verify(): EmailCertificate{
+        return EmailCertificate(
+            id = this.id,
+            email = this.email,
+            key = this.key,
+            expiredTime = this.expiredTime,
+            authentication = true
+        )
+    }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/email/domain/entity/EmailCertificate.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/domain/entity/EmailCertificate.kt
@@ -25,13 +25,12 @@ class EmailCertificate(
     constructor(email: String, key: String, expiredTime: LocalDateTime, authentication: Boolean)
             :this(0, email, key, expiredTime, authentication)
 
-    fun verify(): EmailCertificate{
-        return EmailCertificate(
+    fun verify(): EmailCertificate =
+        EmailCertificate(
             id = this.id,
             email = this.email,
             key = this.key,
             expiredTime = this.expiredTime,
             authentication = true
         )
-    }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/email/domain/repository/EmailCertificateRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/domain/repository/EmailCertificateRepository.kt
@@ -9,4 +9,6 @@ interface EmailCertificateRepository: JpaRepository<EmailCertificate, Long> {
     fun findByKey(key: String): EmailCertificate?
 
     fun existsByEmail(email: String): Boolean
+
+    fun findByEmail(email: String): EmailCertificate?
 }

--- a/src/main/kotlin/com/dotori/v2/domain/email/presentation/EmailSendController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/presentation/EmailSendController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v2/email")
-class EmailSendController(
+class EmailController(
     private val signupEmailSendService: SingupEmailSendService,
     private val passwordChangeEmailSendService: PasswordChangeEmailSendService,
     private val emailCheckService: EmailCheckService
@@ -30,7 +30,7 @@ class EmailSendController(
         return ResponseEntity.ok().build()
     }
 
-    @PostMapping("/verify")
+    @PostMapping("/verify-email")
     fun verifyEmail(@RequestBody emailCheckReqDto: EmailCheckReqDto): ResponseEntity<Void>{
         emailCheckService.execute(emailCheckReqDto.key)
         return ResponseEntity.ok().build()

--- a/src/main/kotlin/com/dotori/v2/domain/email/presentation/EmailSendController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/presentation/EmailSendController.kt
@@ -1,6 +1,8 @@
 package com.dotori.v2.domain.email.presentation
 
+import com.dotori.v2.domain.email.presentation.dto.request.EmailCheckReqDto
 import com.dotori.v2.domain.email.presentation.dto.request.EmailReqDto
+import com.dotori.v2.domain.email.service.EmailCheckService
 import com.dotori.v2.domain.email.service.PasswordChangeEmailSendService
 import com.dotori.v2.domain.email.service.SingupEmailSendService
 import org.springframework.http.ResponseEntity
@@ -12,18 +14,25 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/v2/email")
 class EmailSendController(
-    private val singupEmailSendService: SingupEmailSendService,
-    private val passwordChangeEmailSendService: PasswordChangeEmailSendService
+    private val signupEmailSendService: SingupEmailSendService,
+    private val passwordChangeEmailSendService: PasswordChangeEmailSendService,
+    private val emailCheckService: EmailCheckService
 ){
     @PostMapping("/signup")
     fun sendEmailSignup(@RequestBody emailReqDto: EmailReqDto): ResponseEntity<Void>{
-        singupEmailSendService.execute(emailReqDto)
+        signupEmailSendService.execute(emailReqDto)
         return ResponseEntity.ok().build()
     }
 
     @PostMapping("/password")
     fun sendEmailChangePassword(@RequestBody emailReqDto: EmailReqDto): ResponseEntity<Void>{
         passwordChangeEmailSendService.execute(emailReqDto)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/verify")
+    fun verifyEmail(@RequestBody emailCheckReqDto: EmailCheckReqDto): ResponseEntity<Void>{
+        emailCheckService.execute(emailCheckReqDto.key)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/email/service/impl/EmailCheckServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/service/impl/EmailCheckServiceImpl.kt
@@ -3,17 +3,20 @@ package com.dotori.v2.domain.email.service.impl
 import com.dotori.v2.domain.email.domain.repository.EmailCertificateRepository
 import com.dotori.v2.domain.email.service.EmailCheckService
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @Service
 class EmailCheckServiceImpl(
     private val emailCertificateRepository: EmailCertificateRepository,
 ) : EmailCheckService {
+    @Transactional(rollbackFor = [Exception::class])
     override fun execute(key: String): Boolean {
         val findByKey = emailCertificateRepository.findByKey(key) ?: throw RuntimeException()
-        emailCertificateRepository.deleteByEmail(findByKey.email)
         if (!findByKey.expiredTime.isAfter(LocalDateTime.now()))
             throw RuntimeException()
+        val emailCertificate = findByKey.verify()
+        emailCertificateRepository.save(emailCertificate)
         return true
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/email/service/impl/EmailSendServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/service/impl/EmailSendServiceImpl.kt
@@ -23,7 +23,8 @@ class EmailSendServiceImpl(
         val emailCertificate = EmailCertificate(
             email = emailReqDto.email,
             key = key,
-            expiredTime = LocalDateTime.now().plusMinutes(5)
+            expiredTime = LocalDateTime.now().plusMinutes(5),
+            authentication = false
         )
         emailCertificateRepository.save(emailCertificate)
         return key

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/SignupServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/SignupServiceImpl.kt
@@ -17,8 +17,11 @@ class SignupServiceImpl (
     private val passwordEncoder: PasswordEncoder,
 ): SignupService{
     override fun execute(signupReqDto: SignupReqDto):Long {
-        if(emailCertificateRepository.existsByEmail(signupReqDto.email))
+        val emailCertificate = emailCertificateRepository.findByEmail(signupReqDto.email)
+            ?: throw RuntimeException() // TODO 인증코드 발송 X
+        if(!emailCertificate.authentication)
             throw RuntimeException() // TODO 나중에 예외처리 해야됨 -> 인증된 메일X
+        emailCertificateRepository.delete(emailCertificate)
         if(memberRepository.existsByEmail(signupReqDto.email))
             throw RuntimeException() // TODO 나중에 예외처리 해야됨 -> 이미 존재하는 유저
         val encodedPassword = passwordEncoder.encode(signupReqDto.password)

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/SignupServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/SignupServiceImpl.kt
@@ -16,7 +16,7 @@ class SignupServiceImpl (
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder,
 ): SignupService{
-    override fun execute(signupReqDto: SignupReqDto):Long {
+    override fun execute(signupReqDto: SignupReqDto): Long {
         val emailCertificate = emailCertificateRepository.findByEmail(signupReqDto.email)
             ?: throw RuntimeException() // TODO 인증코드 발송 X
         if(!emailCertificate.authentication)


### PR DESCRIPTION
## 개요
* 기존 이메일 인증 로직은 인증된후 emailCertificate를 제거해서 회원가입시에 emailCertificate가 없으면 회원가입을 진행하는 방식임
* 위의 방식으로 진행하면 메일 인증을 안하고 요청을 보내도 회원가입이 성공함
* 그래서 emailCertificate의 authentication을 확인해서 회원가입을 진행하도록 수정
#6 