### PR TITLE
🔀 :: 31-자습신청 취소 API

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/self_study/domain/repository/SelfStudyRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/domain/repository/SelfStudyRepository.kt
@@ -1,7 +1,9 @@
 package com.dotori.v2.domain.self_study.domain.repository
 
+import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.self_study.domain.entity.SelfStudy
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface SelfStudyRepository : JpaRepository<SelfStudy, Long> {
+    fun deleteByMember(member: Member)
 }

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/excetpion/NotAppliedException.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/excetpion/NotAppliedException.kt
@@ -1,0 +1,6 @@
+package com.dotori.v2.domain.self_study.excetpion
+
+import com.dotori.v2.global.error.ErrorCode
+import com.dotori.v2.global.error.exception.BasicException
+
+class NotAppliedException : BasicException(ErrorCode.SELF_STUDY_CANT_CANCEL)

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/excetpion/NotCancelDayException.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/excetpion/NotCancelDayException.kt
@@ -1,0 +1,6 @@
+package com.dotori.v2.domain.self_study.excetpion
+
+import com.dotori.v2.global.error.ErrorCode
+import com.dotori.v2.global.error.exception.BasicException
+
+class NotCancelDayException : BasicException(ErrorCode.SELF_STUDY_CANT_CANCEL_DATE)

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/excetpion/NotCancelHourException.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/excetpion/NotCancelHourException.kt
@@ -1,0 +1,6 @@
+package com.dotori.v2.domain.self_study.excetpion
+
+import com.dotori.v2.global.error.ErrorCode
+import com.dotori.v2.global.error.exception.BasicException
+
+class NotCancelHourException : BasicException(ErrorCode.SELF_STUDY_CANT_CANCEL_TIME)

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/councillor/CouncillorSelfStudyController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/councillor/CouncillorSelfStudyController.kt
@@ -2,8 +2,10 @@ package com.dotori.v2.domain.self_study.presentation.councillor
 
 import com.dotori.v2.domain.self_study.presentation.dto.SelfStudyInfoResDto
 import com.dotori.v2.domain.self_study.service.ApplySelfStudyService
+import com.dotori.v2.domain.self_study.service.CancelSelfStudyService
 import com.dotori.v2.domain.self_study.service.GetSelfStudyInfoService
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,10 +16,16 @@ import org.springframework.web.bind.annotation.RestController
 class CouncillorSelfStudyController(
     private val applySelfStudyService: ApplySelfStudyService,
     private val getSelfStudyInfoService: GetSelfStudyInfoService,
+    private val cancelSelfStudyService: CancelSelfStudyService
 ) {
     @PostMapping
     fun applySelfStudy(): ResponseEntity<Void> =
         applySelfStudyService.execute()
+            .run { ResponseEntity.ok().build() }
+
+    @DeleteMapping
+    fun cancelSelfStudy(): ResponseEntity<Void> =
+        cancelSelfStudyService.execute()
             .run { ResponseEntity.ok().build() }
 
     @GetMapping("/info")

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/developer/DeveloperSelfStudyController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/developer/DeveloperSelfStudyController.kt
@@ -2,22 +2,26 @@ package com.dotori.v2.domain.self_study.presentation.developer
 
 import com.dotori.v2.domain.self_study.presentation.dto.SelfStudyInfoResDto
 import com.dotori.v2.domain.self_study.service.ApplySelfStudyService
+import com.dotori.v2.domain.self_study.service.CancelSelfStudyService
 import com.dotori.v2.domain.self_study.service.GetSelfStudyInfoService
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/v2/developer/self_study")
 class DeveloperSelfStudyController(
     private val applySelfStudyService: ApplySelfStudyService,
-    private val getSelfStudyInfoService: GetSelfStudyInfoService
+    private val getSelfStudyInfoService: GetSelfStudyInfoService,
+    private val cancelSelfStudyService: CancelSelfStudyService
 ) {
     @PostMapping
     fun applySelfStudy(): ResponseEntity<Void> =
         applySelfStudyService.execute()
+            .run { ResponseEntity.ok().build() }
+
+    @DeleteMapping
+    fun cancelSelfStudy(): ResponseEntity<Void> =
+        cancelSelfStudyService.execute()
             .run { ResponseEntity.ok().build() }
 
     @GetMapping("/info")

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/member/MemberSelfStudyController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/member/MemberSelfStudyController.kt
@@ -2,23 +2,27 @@ package com.dotori.v2.domain.self_study.presentation.member
 
 import com.dotori.v2.domain.self_study.presentation.dto.SelfStudyInfoResDto
 import com.dotori.v2.domain.self_study.service.ApplySelfStudyService
+import com.dotori.v2.domain.self_study.service.CancelSelfStudyService
 import com.dotori.v2.domain.self_study.service.GetSelfStudyInfoService
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 
 @RestController
 @RequestMapping("/v2/member/self_study")
 class MemberSelfStudyController(
     private val applySelfStudyService: ApplySelfStudyService,
-    private val getSelfStudyInfoService: GetSelfStudyInfoService
+    private val getSelfStudyInfoService: GetSelfStudyInfoService,
+    private val cancelSelfStudyService: CancelSelfStudyService
 ) {
     @PostMapping
     fun applySelfStudy(): ResponseEntity<Void> =
         applySelfStudyService.execute()
+            .run { ResponseEntity.ok().build() }
+
+    @DeleteMapping
+    fun cancelSelfStudy(): ResponseEntity<Void> =
+        cancelSelfStudyService.execute()
             .run { ResponseEntity.ok().build() }
 
     @GetMapping("/info")

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/service/CancelSelfStudyService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/service/CancelSelfStudyService.kt
@@ -1,0 +1,5 @@
+package com.dotori.v2.domain.self_study.service
+
+interface CancelSelfStudyService {
+    fun execute()
+}

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/service/impl/ApplySelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/service/impl/ApplySelfStudyServiceImpl.kt
@@ -1,8 +1,6 @@
 package com.dotori.v2.domain.self_study.service.impl
 
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
-import com.dotori.v2.domain.self_study.domain.entity.SelfStudy
-import com.dotori.v2.domain.self_study.domain.repository.SelfStudyRepository
 import com.dotori.v2.domain.self_study.excetpion.SelfStudyOverException
 import com.dotori.v2.domain.self_study.service.ApplySelfStudyService
 import com.dotori.v2.domain.self_study.util.FindSelfStudyCountUtil
@@ -12,7 +10,6 @@ import com.dotori.v2.domain.self_study.util.ValidDayOfWeekAndHourUtil
 import com.dotori.v2.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @Service
 @Transactional(rollbackFor = [Exception::class])
@@ -24,7 +21,7 @@ class ApplySelfStudyServiceImpl(
     private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil
 ) : ApplySelfStudyService{
     override fun execute() {
-        validDayOfWeekAndHourUtil.validate()
+        validDayOfWeekAndHourUtil.validateApply()
         val member = userUtil.fetchCurrentUser()
         val selfStudyCount = findSelfStudyCountUtil.findSelfStudyCount()
         if (selfStudyCount.count >= 50)

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/service/impl/CancelSelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/service/impl/CancelSelfStudyServiceImpl.kt
@@ -1,0 +1,31 @@
+package com.dotori.v2.domain.self_study.service.impl
+
+import com.dotori.v2.domain.member.enums.SelfStudyStatus
+import com.dotori.v2.domain.self_study.domain.repository.SelfStudyRepository
+import com.dotori.v2.domain.self_study.service.CancelSelfStudyService
+import com.dotori.v2.domain.self_study.util.FindSelfStudyCountUtil
+import com.dotori.v2.domain.self_study.util.SelfStudyCheckUtil
+import com.dotori.v2.domain.self_study.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.global.util.UserUtil
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class CancelSelfStudyServiceImpl(
+    private val userUtil: UserUtil,
+    private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil,
+    private val findSelfStudyCountUtil: FindSelfStudyCountUtil,
+    private val selfStudyRepository: SelfStudyRepository,
+    private val selfStudyCheckUtil: SelfStudyCheckUtil
+) : CancelSelfStudyService {
+    override fun execute() {
+        validDayOfWeekAndHourUtil.validateCancel()
+        val findSelfStudyCount = findSelfStudyCountUtil.findSelfStudyCount()
+        val member = userUtil.fetchCurrentUser()
+        selfStudyCheckUtil.isSelfStudyStatusApplied(member)
+        member.updateSelfStudyStatus(SelfStudyStatus.CANT)
+        selfStudyRepository.deleteByMember(member)
+        findSelfStudyCount.removeCount()
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/util/SelfStudyCheckUtil.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/util/SelfStudyCheckUtil.kt
@@ -3,6 +3,7 @@ package com.dotori.v2.domain.self_study.util
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.self_study.excetpion.AlreadyApplySelfStudyException
+import com.dotori.v2.domain.self_study.excetpion.NotAppliedException
 import org.springframework.stereotype.Component
 
 @Component
@@ -10,5 +11,10 @@ class SelfStudyCheckUtil {
     fun isSelfStudyStatusCan(member: Member){
         if (member.selfStudyStatus != SelfStudyStatus.CAN)
             throw AlreadyApplySelfStudyException()
+    }
+
+    fun isSelfStudyStatusApplied(member: Member){
+        if (member.selfStudyStatus != SelfStudyStatus.APPLIED)
+            throw NotAppliedException()
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/util/ValidDayOfWeekAndHourUtil.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/util/ValidDayOfWeekAndHourUtil.kt
@@ -2,13 +2,15 @@ package com.dotori.v2.domain.self_study.util
 
 import com.dotori.v2.domain.self_study.excetpion.NotApplyDayException
 import com.dotori.v2.domain.self_study.excetpion.NotApplyHourException
+import com.dotori.v2.domain.self_study.excetpion.NotCancelDayException
+import com.dotori.v2.domain.self_study.excetpion.NotCancelHourException
 import org.springframework.stereotype.Component
 import java.time.DayOfWeek
 import java.time.LocalDateTime
 
 @Component
 class ValidDayOfWeekAndHourUtil {
-     fun validate() {
+     fun validateApply() {
          val currentTime = LocalDateTime.now()
          val dayOfWeek = currentTime.dayOfWeek
          val hour = currentTime.hour
@@ -16,6 +18,16 @@ class ValidDayOfWeekAndHourUtil {
             throw NotApplyDayException()
         if (hour != 20)
             throw NotApplyHourException()
+    }
+
+    fun validateCancel() {
+        val currentTime = LocalDateTime.now()
+        val dayOfWeek = currentTime.dayOfWeek
+        val hour = currentTime.hour
+        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
+            throw NotCancelDayException()
+        if (hour != 20)
+            throw NotCancelHourException()
     }
 
 }

--- a/src/test/kotlin/com/dotori/v2/domain/self_study/controller/ApplySelfStudyControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/self_study/controller/ApplySelfStudyControllerTest.kt
@@ -4,6 +4,7 @@ import com.dotori.v2.domain.self_study.presentation.councillor.CouncillorSelfStu
 import com.dotori.v2.domain.self_study.presentation.developer.DeveloperSelfStudyController
 import com.dotori.v2.domain.self_study.presentation.member.MemberSelfStudyController
 import com.dotori.v2.domain.self_study.service.ApplySelfStudyService
+import com.dotori.v2.domain.self_study.service.CancelSelfStudyService
 import com.dotori.v2.domain.self_study.service.GetSelfStudyInfoService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -15,9 +16,10 @@ import org.springframework.http.HttpStatus
 class ApplySelfStudyControllerTest : BehaviorSpec({
     val service = mockk<ApplySelfStudyService>()
     val getSelfStudyInfoService = mockk<GetSelfStudyInfoService>()
-    val councillorSelfStudyController = CouncillorSelfStudyController(service, getSelfStudyInfoService)
-    val developerSelfStudyController = DeveloperSelfStudyController(service, getSelfStudyInfoService)
-    val memberSelfStudyController = MemberSelfStudyController(service, getSelfStudyInfoService)
+    val cancelSelfStudyService = mockk<CancelSelfStudyService>()
+    val councillorSelfStudyController = CouncillorSelfStudyController(service, getSelfStudyInfoService, cancelSelfStudyService)
+    val developerSelfStudyController = DeveloperSelfStudyController(service, getSelfStudyInfoService, cancelSelfStudyService)
+    val memberSelfStudyController = MemberSelfStudyController(service, getSelfStudyInfoService, cancelSelfStudyService)
     every { service.execute() } returns Unit
     given("요청이 들어오면") {
         `when`("councillorController is received") {

--- a/src/test/kotlin/com/dotori/v2/domain/self_study/controller/CancelSelfStudyControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/self_study/controller/CancelSelfStudyControllerTest.kt
@@ -1,13 +1,12 @@
 package com.dotori.v2.domain.self_study.controller
 
-import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.self_study.presentation.councillor.CouncillorSelfStudyController
 import com.dotori.v2.domain.self_study.presentation.developer.DeveloperSelfStudyController
-import com.dotori.v2.domain.self_study.presentation.dto.SelfStudyInfoResDto
 import com.dotori.v2.domain.self_study.presentation.member.MemberSelfStudyController
 import com.dotori.v2.domain.self_study.service.ApplySelfStudyService
 import com.dotori.v2.domain.self_study.service.CancelSelfStudyService
 import com.dotori.v2.domain.self_study.service.GetSelfStudyInfoService
+import com.dotori.v2.domain.self_study.service.GetSelfStudyRankService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -18,10 +17,11 @@ import org.springframework.http.HttpStatus
 class CancelSelfStudyControllerTest : BehaviorSpec({
     val applySelfStudyService = mockk<ApplySelfStudyService>()
     val getSelfStudyService = mockk<GetSelfStudyInfoService>()
+    val getSelfStudyRankService = mockk<GetSelfStudyRankService>()
     val service = mockk<CancelSelfStudyService>()
-    val councillorSelfStudyController = CouncillorSelfStudyController(applySelfStudyService, getSelfStudyService, service)
-    val developerSelfStudyController = DeveloperSelfStudyController(applySelfStudyService, getSelfStudyService, service)
-    val memberSelfStudyController = MemberSelfStudyController(applySelfStudyService, getSelfStudyService, service)
+    val councillorSelfStudyController = CouncillorSelfStudyController(applySelfStudyService, getSelfStudyService, getSelfStudyRankService, service)
+    val developerSelfStudyController = DeveloperSelfStudyController(applySelfStudyService, getSelfStudyService, getSelfStudyRankService, service)
+    val memberSelfStudyController = MemberSelfStudyController(applySelfStudyService, getSelfStudyService, getSelfStudyRankService, service)
     every { service.execute() } returns Unit
     given("요청이 들어오면") {
         `when`("councillorController is received") {

--- a/src/test/kotlin/com/dotori/v2/domain/self_study/controller/CancelSelfStudyControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/self_study/controller/CancelSelfStudyControllerTest.kt
@@ -15,17 +15,17 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.http.HttpStatus
 
-class GetSelfStudyInfoControllerTest : BehaviorSpec({
+class CancelSelfStudyControllerTest : BehaviorSpec({
     val applySelfStudyService = mockk<ApplySelfStudyService>()
-    val service = mockk<GetSelfStudyInfoService>()
-    val cancelSelfStudyService = mockk<CancelSelfStudyService>()
-    val councillorSelfStudyController = CouncillorSelfStudyController(applySelfStudyService, service, cancelSelfStudyService)
-    val developerSelfStudyController = DeveloperSelfStudyController(applySelfStudyService, service, cancelSelfStudyService)
-    val memberSelfStudyController = MemberSelfStudyController(applySelfStudyService, service, cancelSelfStudyService)
-    every { service.execute() } returns SelfStudyInfoResDto(1, SelfStudyStatus.CAN)
+    val getSelfStudyService = mockk<GetSelfStudyInfoService>()
+    val service = mockk<CancelSelfStudyService>()
+    val councillorSelfStudyController = CouncillorSelfStudyController(applySelfStudyService, getSelfStudyService, service)
+    val developerSelfStudyController = DeveloperSelfStudyController(applySelfStudyService, getSelfStudyService, service)
+    val memberSelfStudyController = MemberSelfStudyController(applySelfStudyService, getSelfStudyService, service)
+    every { service.execute() } returns Unit
     given("요청이 들어오면") {
         `when`("councillorController is received") {
-            val response = councillorSelfStudyController.getSelfStudyInfo()
+            val response = councillorSelfStudyController.cancelSelfStudy()
             then("서비스가 한번은 실행되어야 함") {
                 verify(exactly = 1) { service.execute() }
             }
@@ -34,7 +34,7 @@ class GetSelfStudyInfoControllerTest : BehaviorSpec({
             }
         }
         `when`("developerController is received") {
-            val response = developerSelfStudyController.getSelfStudyInfo()
+            val response = developerSelfStudyController.cancelSelfStudy()
             then("서비스가 한번은 실행되어야 함") {
                 verify(exactly = 2) { service.execute() }
             }
@@ -43,7 +43,7 @@ class GetSelfStudyInfoControllerTest : BehaviorSpec({
             }
         }
         `when`("memberController is received") {
-            val response = memberSelfStudyController.getSelfStudyInfo()
+            val response = memberSelfStudyController.cancelSelfStudy()
             then("서비스가 한번은 실행되어야 함") {
                 verify(exactly = 3) { service.execute() }
             }

--- a/src/test/kotlin/com/dotori/v2/domain/self_study/controller/GetSelfStudyRankControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/self_study/controller/GetSelfStudyRankControllerTest.kt
@@ -7,6 +7,7 @@ import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyInfoResDto
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyMemberListResDto
 import com.dotori.v2.domain.self_study.presentation.member.MemberSelfStudyController
 import com.dotori.v2.domain.self_study.service.ApplySelfStudyService
+import com.dotori.v2.domain.self_study.service.CancelSelfStudyService
 import com.dotori.v2.domain.self_study.service.GetSelfStudyInfoService
 import com.dotori.v2.domain.self_study.service.GetSelfStudyRankService
 import io.kotest.core.spec.style.BehaviorSpec
@@ -20,9 +21,10 @@ class GetSelfStudyRankControllerTest : BehaviorSpec({
     val applySelfStudyService = mockk<ApplySelfStudyService>()
     val getSelfStudyInfoService = mockk<GetSelfStudyInfoService>()
     val service = mockk<GetSelfStudyRankService>()
-    val councillorSelfStudyController = CouncillorSelfStudyController(applySelfStudyService, getSelfStudyInfoService, service)
-    val developerSelfStudyController = DeveloperSelfStudyController(applySelfStudyService, getSelfStudyInfoService, service)
-    val memberSelfStudyController = MemberSelfStudyController(applySelfStudyService, getSelfStudyInfoService, service)
+    val cancelSelfStudyService = mockk<CancelSelfStudyService>()
+    val councillorSelfStudyController = CouncillorSelfStudyController(applySelfStudyService, getSelfStudyInfoService, service, cancelSelfStudyService)
+    val developerSelfStudyController = DeveloperSelfStudyController(applySelfStudyService, getSelfStudyInfoService, service, cancelSelfStudyService)
+    val memberSelfStudyController = MemberSelfStudyController(applySelfStudyService, getSelfStudyInfoService, service, cancelSelfStudyService)
     every { service.execute() } returns SelfStudyMemberListResDto(mutableListOf())
     given("요청이 들어오면") {
         `when`("councillorController is received") {

--- a/src/test/kotlin/com/dotori/v2/domain/self_study/service/ApplySelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/self_study/service/ApplySelfStudyServiceTest.kt
@@ -43,7 +43,7 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
             roles = Collections.singletonList(Role.ROLE_MEMBER)
         )
         val selfStudyCount = SelfStudyCount(id = 1)
-        every { validDayOfWeekAndHourUtil.validate() } returns Unit
+        every { validDayOfWeekAndHourUtil.validateApply() } returns Unit
         every { userUtil.fetchCurrentUser() } returns testMember
         every { findSelfStudyCountUtil.findSelfStudyCount() } returns selfStudyCount
         every { selfStudyCheckUtil.isSelfStudyStatusCan(testMember) } returns Unit

--- a/src/test/kotlin/com/dotori/v2/domain/self_study/service/CancelSelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/self_study/service/CancelSelfStudyServiceTest.kt
@@ -1,0 +1,54 @@
+package com.dotori.v2.domain.self_study.service
+
+import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
+import com.dotori.v2.domain.member.enums.Role
+import com.dotori.v2.domain.self_study.domain.entity.SelfStudyCount
+import com.dotori.v2.domain.self_study.domain.repository.SelfStudyRepository
+import com.dotori.v2.domain.self_study.service.impl.CancelSelfStudyServiceImpl
+import com.dotori.v2.domain.self_study.util.FindSelfStudyCountUtil
+import com.dotori.v2.domain.self_study.util.SelfStudyCheckUtil
+import com.dotori.v2.domain.self_study.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.global.util.UserUtil
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.*
+
+class CancelSelfStudyServiceTest : BehaviorSpec({
+    val userUtil = mockk<UserUtil>()
+    val findSelfStudyCountUtil = mockk<FindSelfStudyCountUtil>()
+    val validDayOfWeekAndHourUtil = mockk<ValidDayOfWeekAndHourUtil>()
+    val selfStudyRepository = mockk<SelfStudyRepository>()
+    val selfStudyCheckUtil = mockk<SelfStudyCheckUtil>()
+    val serviceImpl = CancelSelfStudyServiceImpl(
+        userUtil,
+        validDayOfWeekAndHourUtil,
+        findSelfStudyCountUtil,
+        selfStudyRepository,
+        selfStudyCheckUtil
+    )
+    given("유저가 주어지고") {
+        val testMember = Member(
+            memberName = "test",
+            stuNum = "2116",
+            email = "test@gsm.hs.kr",
+            password = "test",
+            gender = Gender.MAN,
+            roles = Collections.singletonList(Role.ROLE_MEMBER)
+        )
+        val selfStudyCount = SelfStudyCount(id = 1)
+        every { validDayOfWeekAndHourUtil.validateCancel() } returns Unit
+        every { userUtil.fetchCurrentUser() } returns testMember
+        every { findSelfStudyCountUtil.findSelfStudyCount() } returns selfStudyCount
+        every { selfStudyCheckUtil.isSelfStudyStatusApplied(testMember) } returns Unit
+        every { selfStudyRepository.deleteByMember(testMember) } returns Unit
+        `when`("서비스를 실행하면"){
+            serviceImpl.execute()
+            then("delete 쿼리가 날라가야함"){
+                verify(exactly = 1) { selfStudyRepository.deleteByMember(testMember) }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 개요
* 자습신청 취소 API 개발
## 작업내용
* 자습신청 취소 API
* 테스트 코드
## 변경 사항
* util객체의 메서드 네이밍 수정