### PR TITLE
🔀 :: 134 - 로그인하지 않고 패스워드 변경

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/email/exception/EmailAuthNotFoundException.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/exception/EmailAuthNotFoundException.kt
@@ -3,5 +3,5 @@ package com.dotori.v2.domain.email.exception
 import com.dotori.v2.global.error.ErrorCode
 import com.dotori.v2.global.error.exception.BasicException
 
-class EmailSendFailException : BasicException(ErrorCode.EMAIL_SEND_FAIL){
+class EmailAuthNotFoundException : BasicException(ErrorCode.MAIL_AUTH_NOT_FOUND){
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/AuthController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/AuthController.kt
@@ -1,6 +1,6 @@
 package com.dotori.v2.domain.member.presentation
 
-import com.dotori.v2.domain.member.presentation.data.req.NewPasswordReqDto
+import com.dotori.v2.domain.member.presentation.data.req.NoAuthNewPasswordReqDto
 import com.dotori.v2.domain.member.presentation.data.req.SignInReqDto
 import com.dotori.v2.domain.member.presentation.data.req.SignupReqDto
 import com.dotori.v2.domain.member.presentation.data.res.RefreshResDto
@@ -40,7 +40,7 @@ class AuthController (
         ResponseEntity.ok(refreshService.execute(refreshToken))
 
     @PatchMapping("/password")
-    fun changePassword(@Valid @RequestBody newPasswordReqDto: NewPasswordReqDto): ResponseEntity<Void> =
+    fun changePassword(@Valid @RequestBody newPasswordReqDto: NoAuthNewPasswordReqDto): ResponseEntity<Void> =
         changePasswordService.execute(newPasswordReqDto)
             .run { ResponseEntity.ok().build() }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NewPasswordReqDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NewPasswordReqDto.kt
@@ -3,7 +3,7 @@ package com.dotori.v2.domain.member.presentation.data.req
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
 
-data class NewPasswordReqDto(
+open class NewPasswordReqDto(
     @field:NotBlank
     @field:Size(min = 4)
     val currentPassword: String,

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NoAuthNewPasswordReqDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NoAuthNewPasswordReqDto.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.domain.member.presentation.data.req
+
+class NoAuthNewPasswordReqDto(
+    val email: String,
+    newPassword: String,
+    currentPassword: String,
+) : NewPasswordReqDto(currentPassword, newPassword)

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/ChangePasswordService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/ChangePasswordService.kt
@@ -1,7 +1,7 @@
 package com.dotori.v2.domain.member.service
 
-import com.dotori.v2.domain.member.presentation.data.req.NewPasswordReqDto
+import com.dotori.v2.domain.member.presentation.data.req.NoAuthNewPasswordReqDto
 
 interface ChangePasswordService {
-    fun execute(newPasswordReqDto: NewPasswordReqDto)
+    fun execute(newPasswordReqDto: NoAuthNewPasswordReqDto)
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/ChangePasswordServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/ChangePasswordServiceImpl.kt
@@ -2,11 +2,12 @@ package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.email.domain.repository.EmailCertificateRepository
 import com.dotori.v2.domain.email.exception.EmailNotBeenException
-import com.dotori.v2.domain.email.exception.EmailSendFailException
+import com.dotori.v2.domain.email.exception.EmailAuthNotFoundException
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.member.exception.PasswordMismatchException
-import com.dotori.v2.domain.member.presentation.data.req.NewPasswordReqDto
+import com.dotori.v2.domain.member.presentation.data.req.NoAuthNewPasswordReqDto
 import com.dotori.v2.domain.member.service.ChangePasswordService
-import com.dotori.v2.global.util.UserUtil
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,16 +15,17 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(rollbackFor = [Exception::class])
 class ChangePasswordServiceImpl(
-    private val userUtil: UserUtil,
+    private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder,
     private val emailCertificateRepository: EmailCertificateRepository,
 ) : ChangePasswordService {
-    override fun execute(newPasswordReqDto: NewPasswordReqDto) {
-        val member = userUtil.fetchCurrentUser()
-        val emailCertificate = emailCertificateRepository.findByEmail(member.email)
-            ?: throw EmailSendFailException()
+    override fun execute(newPasswordReqDto: NoAuthNewPasswordReqDto) {
+        val emailCertificate = emailCertificateRepository.findByEmail(newPasswordReqDto.email)
+            ?: throw EmailAuthNotFoundException()
         if (!emailCertificate.authentication)
             throw EmailNotBeenException()
+        val member = (memberRepository.findByEmail(newPasswordReqDto.email)
+            ?: throw MemberNotFoundException())
         if (!passwordEncoder.matches(newPasswordReqDto.currentPassword, member.password))
             throw PasswordMismatchException()
         member.updatePassword(passwordEncoder.encode(newPasswordReqDto.newPassword))

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/SignupServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/SignupServiceImpl.kt
@@ -3,7 +3,7 @@ package com.dotori.v2.domain.member.service.impl
 import com.dotori.v2.domain.email.domain.repository.EmailCertificateRepository
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.email.exception.EmailNotBeenException
-import com.dotori.v2.domain.email.exception.EmailSendFailException
+import com.dotori.v2.domain.email.exception.EmailAuthNotFoundException
 import com.dotori.v2.domain.member.exception.MemberAlreadyException
 import com.dotori.v2.domain.member.presentation.data.req.SignupReqDto
 import com.dotori.v2.domain.member.service.SignupService
@@ -20,7 +20,7 @@ class SignupServiceImpl(
 ): SignupService {
     override fun execute(signupReqDto: SignupReqDto): Long {
         val emailCertificate = emailCertificateRepository.findByEmail(signupReqDto.email)
-            ?: throw EmailSendFailException()
+            ?: throw EmailAuthNotFoundException()
         if(!emailCertificate.authentication)
             throw EmailNotBeenException()
         emailCertificateRepository.delete(emailCertificate)

--- a/src/main/kotlin/com/dotori/v2/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dotori/v2/global/error/ErrorCode.kt
@@ -72,5 +72,8 @@ enum class ErrorCode(
 
     // *** RULE ***
     RULE_NO_HISTORY(HttpStatus.ACCEPTED.value(), "규정위반 내역이 없습니다."),
-    RULE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 규정위반 내역을 찾지 못하였습니다.")
+    RULE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 규정위반 내역을 찾지 못하였습니다."),
+
+    //*** MAIL ***
+    MAIL_AUTH_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "메일을 발송하지 않았거나 만료되었습니다.")
 }


### PR DESCRIPTION
💡 개요
* 로그인하지 않고 패스워드 변경

📃 작업내용
* 이메일 인증객체를 못 찾았을때 예외를 변경
* 로그인하고 인증없이 로그인하는 로직을 로그인하지 않고 패스워드를 변경할 수 있는 로직으로 변경

🔀 변경사항
* email, currentPassword, newPassword를 body로 받게 변경

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타