### PR TITLE
🔀 :: 157-이메일 인증 번호 보내는 500 에러 해결

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/email/domain/entity/EmailCertificate.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/domain/entity/EmailCertificate.kt
@@ -16,7 +16,7 @@ class EmailCertificate(
     val email: String,
     @Column(name = "certificate_key", nullable = false)
     val key: String,
-    @Column(name = "certificate_expiredTime", nullable = false)
+    @Column(name = "certificate_expired_time", nullable = false)
     val expiredTime: LocalDateTime,
     @Column(name = "certificate_authentication", nullable = false)
     val authentication: Boolean


### PR DESCRIPTION
💡 개요
157-이메일 인증 번호 보내는 500 에러 해결
📃 작업내용
기존 DB와 Entity 구성이 달라 컬럼 구성 변경(Aws내에서 작업함)

🔀 변경사항
기존 ManyToOne member로 식별 하지 않고 authentication 컬럼으로 구별하기 때문에 기존 Email_certificate 테이블이 변경됌

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타