### PR TITLE
🔀 :: 로그인 되지 않았을때 비번병경할때 현재 비밀번호를 입력하지 않고 변경하게끔 수정

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NewPasswordReqDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NewPasswordReqDto.kt
@@ -1,9 +1,13 @@
 package com.dotori.v2.domain.member.presentation.data.req
 
 import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
 import javax.validation.constraints.Size
 
-open class NewPasswordReqDto(
+data class NewPasswordReqDto(
+    @field:NotBlank
+    @field:Pattern(regexp = "^[a-zA-Z0-9]+@gsm.hs.kr$")
+    val email: String,
     @field:NotBlank
     @field:Size(min = 4)
     val currentPassword: String,

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NoAuthNewPasswordReqDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NoAuthNewPasswordReqDto.kt
@@ -1,7 +1,14 @@
 package com.dotori.v2.domain.member.presentation.data.req
 
-class NoAuthNewPasswordReqDto(
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+
+data class NoAuthNewPasswordReqDto(
+    @field:NotBlank
+    @field:Pattern(regexp = "^[a-zA-Z0-9]+@gsm.hs.kr$")
     val email: String,
-    newPassword: String,
-    currentPassword: String,
-) : NewPasswordReqDto(currentPassword, newPassword)
+    @field:NotBlank
+    @field:Size(min = 4)
+    val newPassword: String,
+)

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/ChangePasswordServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/ChangePasswordServiceImpl.kt
@@ -26,8 +26,6 @@ class ChangePasswordServiceImpl(
             throw EmailNotBeenException()
         val member = (memberRepository.findByEmail(newPasswordReqDto.email)
             ?: throw MemberNotFoundException())
-        if (!passwordEncoder.matches(newPasswordReqDto.currentPassword, member.password))
-            throw PasswordMismatchException()
         member.updatePassword(passwordEncoder.encode(newPasswordReqDto.newPassword))
     }
 }

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/ChangePasswordControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/ChangePasswordControllerTest.kt
@@ -21,7 +21,7 @@ class ChangePasswordControllerTest : BehaviorSpec({
 
     given("요청이 들어오면") {
         `when`("is received") {
-            val request = NewPasswordReqDto("", "")
+            val request = NewPasswordReqDto("", "", "")
             every { changePasswordService.execute(request) } returns Unit
             val response = authController.changePassword(request)
             then("서비스가 한번은 실행되어야 함") {

--- a/src/test/kotlin/com/dotori/v2/domain/member/service/ChangePasswordServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/service/ChangePasswordServiceTest.kt
@@ -36,10 +36,9 @@ class ChangePasswordServiceTest : BehaviorSpec({
             roles = Collections.singletonList(Role.ROLE_MEMBER)
         )
         val emailCertificate = EmailCertificate(1, testMember.email, "testKey", LocalDateTime.now(), true)
-        val request = NoAuthNewPasswordReqDto("test@gsm.hs.kr", testMember.password, "1234")
+        val request = NoAuthNewPasswordReqDto("test@gsm.hs.kr", "1234")
         every { repository.findByEmail(request.email) } returns testMember
         every { emailCertificateRepository.findByEmail(testMember.email) } returns emailCertificate
-        every { passwordEncoder.matches(request.currentPassword, testMember.password) } returns true
         every { passwordEncoder.encode(request.newPassword) } returns request.newPassword
         `when`("서비스를 실행하면"){
             changePasswordServiceImpl.execute(request)


### PR DESCRIPTION
💡 개요
* 로그인 하기전 비번변경에선 현재 비밀번호 입력 안받게 수정해달라해서 수정.

📃 작업내용

🔀 변경사항

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타