### PR TITLE
🔀 :: 167 - 자습, 안마의자 정보 반환하는 로직 수정

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/massage/service/impl/GetMassageInfoServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/massage/service/impl/GetMassageInfoServiceImpl.kt
@@ -1,10 +1,12 @@
 package com.dotori.v2.domain.massage.service.impl
 
+import com.dotori.v2.domain.massage.domain.entity.MassageCount
 import com.dotori.v2.domain.massage.domain.repository.MassageCountRepository
 import com.dotori.v2.domain.massage.exception.MassageOverException
 import com.dotori.v2.domain.massage.presentation.dto.res.MassageInfoResDto
 import com.dotori.v2.domain.massage.service.GetMassageInfoService
 import com.dotori.v2.domain.massage.util.ValidDayOfWeekAndHourMassageUtil
+import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.enums.MassageStatus
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyInfoResDto
@@ -23,21 +25,29 @@ class GetMassageInfoServiceImpl(
     override fun execute(): MassageInfoResDto {
         val massageCount = massageCountRepository.findMassageCountById(1L)
         val member = userUtil.fetchCurrentUser()
-        try {
-            validDayOfWeekAndHourMassageUtil.validateApply()
-            if (massageCount.count >= massageCount.limit)
-                throw MassageOverException()
-        } catch (ex: BasicException){
+        if (isMassageStatusCan(member) && validMassageApplyCant(massageCount))
             return MassageInfoResDto(
                 count = massageCount.count,
                 massageStatus = MassageStatus.CANT,
                 limit = massageCount.limit
             )
-        }
         return MassageInfoResDto(
             count = massageCount.count,
             massageStatus = member.massageStatus,
             limit = massageCount.limit
         )
+    }
+
+    private fun isMassageStatusCan(member: Member) = member.massageStatus == MassageStatus.CAN
+
+    private fun validMassageApplyCant(massageCount: MassageCount): Boolean {
+        try {
+            validDayOfWeekAndHourMassageUtil.validateApply()
+            if (massageCount.count >= massageCount.limit)
+                throw MassageOverException()
+        } catch (ex: BasicException) {
+            return true
+        }
+        return false
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/service/impl/GetSelfStudyInfoServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/service/impl/GetSelfStudyInfoServiceImpl.kt
@@ -1,6 +1,8 @@
 package com.dotori.v2.domain.self_study.service.impl
 
+import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
+import com.dotori.v2.domain.self_study.domain.entity.SelfStudyCount
 import com.dotori.v2.domain.self_study.domain.repository.SelfStudyCountRepository
 import com.dotori.v2.domain.self_study.excetpion.SelfStudyOverException
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyInfoResDto
@@ -21,21 +23,29 @@ class GetSelfStudyInfoServiceImpl(
     override fun execute(): SelfStudyInfoResDto {
         val selfStudyCount = selfStudyCountRepository.findSelfStudyCountById(1)
         val member = userUtil.fetchCurrentUser()
-        try {
-            validDayOfWeekAndHourUtil.validateApply()
-            if (selfStudyCount.count >= selfStudyCount.limit)
-                throw SelfStudyOverException()
-        } catch (ex: BasicException){
+        if (isSelfStudyStatusCan(member) && validSelfStudyApplyCant(selfStudyCount))
             return SelfStudyInfoResDto(
                 count = selfStudyCount.count,
                 limit = selfStudyCount.limit,
                 selfStudyStatus = SelfStudyStatus.CANT
             )
-        }
         return SelfStudyInfoResDto(
             count = selfStudyCount.count,
             limit = selfStudyCount.limit,
             selfStudyStatus = member.selfStudyStatus
         )
+    }
+
+    private fun isSelfStudyStatusCan(member: Member) = member.selfStudyStatus == SelfStudyStatus.CAN
+
+    private fun validSelfStudyApplyCant(selfStudyCount: SelfStudyCount): Boolean {
+        try {
+            validDayOfWeekAndHourUtil.validateApply()
+            if (selfStudyCount.count >= selfStudyCount.limit)
+                throw SelfStudyOverException()
+        } catch (ex: BasicException) {
+            return true
+        }
+        return false
     }
 }


### PR DESCRIPTION
💡 개요
* 자습, 안마의자를 신청취소할때 인원수가 차있으면 취소못함

📃 작업내용
* 자습, 안마의자 정보 반환하는 로직수정

🔀 변경사항

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타