### PR TITLE
학생정보 자습 상태 응답값 변경 및 검색 필터 로직 개선

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/music/service/impl/DeleteMyMusicServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/service/impl/DeleteMyMusicServiceImpl.kt
@@ -7,6 +7,7 @@ import com.dotori.v2.domain.music.domain.repository.MusicRepository
 import com.dotori.v2.domain.music.exception.MusicNotFoundException
 import com.dotori.v2.domain.music.exception.NotMyMusicException
 import com.dotori.v2.domain.music.service.DeleteMusicService
+import com.dotori.v2.domain.music.service.DeleteMyMusicService
 import com.dotori.v2.global.util.UserUtil
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -17,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional
 class DeleteMyMusicServiceImpl(
     private val musicRepository: MusicRepository,
     private val userUtil: UserUtil
-) : DeleteMusicService {
+) : DeleteMyMusicService {
     override fun execute(musicId: Long) {
         val music: Music = musicRepository.findByIdOrNull(musicId) ?: throw MusicNotFoundException()
         val member: Member = userUtil.fetchCurrentUser()

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/admin/AdminSelfStudyController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/admin/AdminSelfStudyController.kt
@@ -5,6 +5,7 @@ import com.dotori.v2.domain.self_study.presentation.dto.req.SelfStudyLimitReqDto
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyInfoResDto
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyMemberListResDto
 import com.dotori.v2.domain.self_study.service.*
+import com.dotori.v2.domain.stu_info.exception.SelfStudySearchReqDto
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -31,7 +32,7 @@ class AdminSelfStudyController(
         ResponseEntity.ok(getSelfStudyRankService.execute())
 
     @GetMapping("/search")
-    fun searchSelfStudy(searchRequestDto: SearchRequestDto): ResponseEntity<SelfStudyMemberListResDto> =
+    fun searchSelfStudy(searchRequestDto: SelfStudySearchReqDto): ResponseEntity<SelfStudyMemberListResDto> =
         ResponseEntity.ok(getSelfStudyByStuNumAndNameService.execute(searchRequestDto))
 
     @PutMapping("/ban/{user_id}")

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/councillor/CouncillorSelfStudyController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/councillor/CouncillorSelfStudyController.kt
@@ -5,6 +5,7 @@ import com.dotori.v2.domain.self_study.presentation.dto.req.SelfStudyLimitReqDto
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyInfoResDto
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyMemberListResDto
 import com.dotori.v2.domain.self_study.service.*
+import com.dotori.v2.domain.stu_info.exception.SelfStudySearchReqDto
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -42,7 +43,7 @@ class CouncillorSelfStudyController(
         ResponseEntity.ok(getSelfStudyRankService.execute())
 
     @GetMapping("/search")
-    fun searchSelfStudy(searchRequestDto: SearchRequestDto): ResponseEntity<SelfStudyMemberListResDto> =
+    fun searchSelfStudy(searchRequestDto: SelfStudySearchReqDto): ResponseEntity<SelfStudyMemberListResDto> =
         ResponseEntity.ok(getSelfStudyByStuNumAndNameService.execute(searchRequestDto))
 
     @PutMapping("/ban/{user_id}")

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/developer/DeveloperSelfStudyController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/developer/DeveloperSelfStudyController.kt
@@ -5,6 +5,7 @@ import com.dotori.v2.domain.self_study.presentation.dto.req.SelfStudyLimitReqDto
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyInfoResDto
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyMemberListResDto
 import com.dotori.v2.domain.self_study.service.*
+import com.dotori.v2.domain.stu_info.exception.SelfStudySearchReqDto
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -42,7 +43,7 @@ class DeveloperSelfStudyController(
         ResponseEntity.ok(getSelfStudyRankService.execute())
 
     @GetMapping("/search")
-    fun searchSelfStudy(searchRequestDto: SearchRequestDto): ResponseEntity<SelfStudyMemberListResDto> =
+    fun searchSelfStudy(searchRequestDto: SelfStudySearchReqDto): ResponseEntity<SelfStudyMemberListResDto> =
         ResponseEntity.ok(getSelfStudyByStuNumAndNameService.execute(searchRequestDto))
 
     @PutMapping("/ban/{user_id}")

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/member/MemberSelfStudyController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/member/MemberSelfStudyController.kt
@@ -3,6 +3,7 @@ package com.dotori.v2.domain.self_study.presentation.member
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyInfoResDto
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyMemberListResDto
 import com.dotori.v2.domain.self_study.service.*
+import com.dotori.v2.domain.stu_info.exception.SelfStudySearchReqDto
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -36,6 +37,6 @@ class MemberSelfStudyController(
         ResponseEntity.ok(getSelfStudyRankService.execute())
 
     @GetMapping("/search")
-    fun searchSelfStudy(searchRequestDto: SearchRequestDto): ResponseEntity<SelfStudyMemberListResDto> =
+    fun searchSelfStudy(searchRequestDto: SelfStudySearchReqDto): ResponseEntity<SelfStudyMemberListResDto> =
         ResponseEntity.ok(getSelfStudyByStuNumAndNameService.execute(searchRequestDto))
 }

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/service/GetSelfStudyByStuNumAndNameService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/service/GetSelfStudyByStuNumAndNameService.kt
@@ -1,8 +1,9 @@
 package com.dotori.v2.domain.self_study.service
 
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyMemberListResDto
+import com.dotori.v2.domain.stu_info.exception.SelfStudySearchReqDto
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 
 interface GetSelfStudyByStuNumAndNameService {
-    fun execute(searchRequestDto: SearchRequestDto): SelfStudyMemberListResDto
+    fun execute(searchRequestDto: SelfStudySearchReqDto): SelfStudyMemberListResDto
 }

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/service/impl/GetSelfStudyByStuNumAndNameServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/service/impl/GetSelfStudyByStuNumAndNameServiceImpl.kt
@@ -1,10 +1,12 @@
 package com.dotori.v2.domain.self_study.service.impl
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.self_study.domain.repository.SelfStudyRepository
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyMemberListResDto
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyMemberResDto
 import com.dotori.v2.domain.self_study.service.GetSelfStudyByStuNumAndNameService
+import com.dotori.v2.domain.stu_info.exception.SelfStudySearchReqDto
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,27 +16,26 @@ import org.springframework.transaction.annotation.Transactional
 class GetSelfStudyByStuNumAndNameServiceImpl(
     private val selfStudyRepository: SelfStudyRepository,
 ) : GetSelfStudyByStuNumAndNameService {
-    override fun execute(searchRequestDto: SearchRequestDto): SelfStudyMemberListResDto {
-        val memberList = selfStudyRepository.findAllOrderByCreatedDateAsc().map { it.member }
+    override fun execute(searchRequestDto: SelfStudySearchReqDto): SelfStudyMemberListResDto {
+        val memberList = selfStudyRepository.findAllOrderByCreatedDateAsc()
+            .filter {
+                if(searchRequestDto.name != null) it.member.memberName == searchRequestDto.name else true
+            }
+            .map { it.member }
         return getMemberCondition(searchRequestDto, memberList)
     }
 
-    private fun getMemberCondition(searchRequestDto: SearchRequestDto, memberList: List<Member>): SelfStudyMemberListResDto {
-        var filterMember: List<Member> = memberList
-
-        if(searchRequestDto.name != null)
-            filterMember = filterMember.filter { it.memberName == searchRequestDto.name }
-        if(searchRequestDto.grade != null)
-            filterMember = filterMember.filter { it.stuNum.substring(0, 1) == searchRequestDto.grade}
-        if(searchRequestDto.classNum != null)
-            filterMember = filterMember.filter { it.stuNum.substring(1, 2) == searchRequestDto.classNum }
-        if(searchRequestDto.gender != null)
-            filterMember = filterMember.filter { it.gender.name == searchRequestDto.gender }
-        if(searchRequestDto.role != null)
-            filterMember = filterMember.filter { it.roles[0].name == searchRequestDto.role }
-        if(searchRequestDto.selfStudyCheck != null) {
-            filterMember = filterMember.filter { it.selfStudyCheck == searchRequestDto.selfStudyCheck }
+    private fun getMemberCondition(searchRequestDto: SelfStudySearchReqDto, memberList: List<Member>): SelfStudyMemberListResDto {
+        val filterMember = searchRequestDto.run {
+            memberList.filter {
+                if (grade != null) it.stuNum.startsWith(grade) else true
+            }.filter {
+                if (classNum != null) it.stuNum.substring(1, 2) == classNum else true
+            }.filter {
+                if (gender != null) it.gender.name == gender else true
+            }.toList()
         }
+
         return SelfStudyMemberListResDto(filterMember.mapIndexed{index, it -> SelfStudyMemberResDto(index + 1L, it) })
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/stu_info/exception/SelfStudySearchReqDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/stu_info/exception/SelfStudySearchReqDto.kt
@@ -1,0 +1,10 @@
+package com.dotori.v2.domain.stu_info.exception
+
+import org.springframework.web.bind.annotation.RequestParam
+
+data class SelfStudySearchReqDto(
+    @RequestParam(value = "name", required = false) val name: String?,
+    @RequestParam(value = "grade", required = false) val grade: String?,
+    @RequestParam(value = "classNum", required = false) val classNum: String?,
+    @RequestParam(value = "gender", required = false) val gender: String?,
+)

--- a/src/main/kotlin/com/dotori/v2/domain/stu_info/presentation/data/req/SearchRequestDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/stu_info/presentation/data/req/SearchRequestDto.kt
@@ -1,5 +1,6 @@
 package com.dotori.v2.domain.stu_info.presentation.data.req
 
+import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import org.springframework.web.bind.annotation.RequestParam
 
 data class SearchRequestDto(
@@ -8,5 +9,5 @@ data class SearchRequestDto(
     @RequestParam(value = "classNum", required = false) val classNum: String?,
     @RequestParam(value = "gender", required = false) val gender: String?,
     @RequestParam(value = "role", required = false) val role: String?,
-    @RequestParam(value = "selfStudy", required = false) val selfStudyCheck: Boolean?,
+    @RequestParam(value = "selfStudy", required = false) val selfStudyStatus: SelfStudyStatus?,
 )

--- a/src/main/kotlin/com/dotori/v2/domain/stu_info/presentation/data/res/SearchStudentListResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/stu_info/presentation/data/res/SearchStudentListResDto.kt
@@ -2,6 +2,7 @@ package com.dotori.v2.domain.stu_info.presentation.data.res
 
 import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
+import com.dotori.v2.domain.member.enums.SelfStudyStatus
 
 data class SearchStudentListResDto(
     val id: Long,
@@ -10,5 +11,5 @@ data class SearchStudentListResDto(
     val stuNum: String,
     val gender: Gender,
     val role: Role,
-    val selfStudyCheck: Boolean
+    val selfStudyStatus: SelfStudyStatus
 )

--- a/src/main/kotlin/com/dotori/v2/domain/stu_info/service/impl/SearchStudentServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/stu_info/service/impl/SearchStudentServiceImpl.kt
@@ -2,6 +2,7 @@ package com.dotori.v2.domain.stu_info.service.impl
 
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 import com.dotori.v2.domain.stu_info.presentation.data.res.SearchStudentListResDto
 import com.dotori.v2.domain.stu_info.service.SearchStudentService
@@ -41,7 +42,8 @@ class SearchStudentServiceImpl(
             }.filter {
                 if (role != null) it.roles.getOrNull(0)?.name == role else true
             }.filter {
-                if (selfStudyCheck != null) it.selfStudyCheck == selfStudyCheck else true
+                if(selfStudyStatus == SelfStudyStatus.IMPOSSIBLE) it.selfStudyStatus == selfStudyStatus || it.selfStudyStatus == SelfStudyStatus.CANT
+                else if (selfStudyStatus != null) it.selfStudyStatus == selfStudyStatus else true
             }.toList()
         }
 
@@ -53,7 +55,7 @@ class SearchStudentServiceImpl(
                 stuNum = it.stuNum,
                 gender = it.gender,
                 role = it.roles[0],
-                selfStudyCheck = it.selfStudyCheck
+                selfStudyStatus = it.selfStudyStatus
             )
         }
     }


### PR DESCRIPTION
💡 개요
학생정보 자습 상태 응답값 변경 및 검색 필터 로직 개선

📃 작업내용
1. 학생정보에서 자습신청 상태값을 응답값으로 보내주던것을 -> 해당 멤버 자체 자습상태 응답 값으로 변경
2. 자습신청 검색 필터에서 불필요한 request 부분 및 로직 개선

🔀 변경사항

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타