### PR TITLE
#229 유저 검색 서비스 QueryDSL 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(Dependencies.SPRING_CLOUD)
     implementation(Dependencies.QUERY_DSL)
     implementation(Dependencies.QUERY_DSL_APT)
+    kapt(Dependencies.QUERY_DSL_APT)
 }
 
 tasks.withType<KotlinCompile> {
@@ -78,7 +79,5 @@ buildscript {
         classpath(Dependencies.KOTEST_PLUG_IN)
     }
 }
-
-
 
 apply(plugin = "io.kotest")

--- a/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepository.kt
@@ -1,0 +1,8 @@
+package com.dotori.v2.domain.member.domain.repository
+
+import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
+
+interface CustomMemberRepository {
+    fun search(searchRequestDto: SearchRequestDto): List<Member>
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepositoryImpl.kt
@@ -1,12 +1,51 @@
 package com.dotori.v2.domain.member.domain.repository
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.domain.entity.QMember.member
+import com.dotori.v2.domain.member.enums.Gender
+import com.dotori.v2.domain.member.enums.Role
+import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+import org.springframework.util.StringUtils.hasText
 
-class CustomMemberRepositoryImpl : CustomMemberRepository {
-
+@Repository
+class CustomMemberRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : CustomMemberRepository {
 
     override fun search(searchRequestDto: SearchRequestDto): List<Member> {
-        TODO("Not yet implemented")
+        return queryFactory.selectFrom(member)
+            .where(
+                nameEq(searchRequestDto.name),
+                gradeEq(searchRequestDto.grade),
+                classNumEq(searchRequestDto.classNum),
+                genderEq(searchRequestDto.gender),
+                roleEq(searchRequestDto.role),
+                selfStudyStatusEq(searchRequestDto.selfStudyStatus)
+            )
+            .orderBy(member.stuNum.asc())
+            .fetch()
     }
+
+    private fun nameEq(name: String?): BooleanExpression? =
+        if(hasText(name)) member.memberName.eq(name) else null
+
+    private fun gradeEq(grade: String?): BooleanExpression? =
+        if(hasText(grade)) member.stuNum.startsWith(grade) else null
+
+    private fun classNumEq(classNum: String?): BooleanExpression? =
+        if(hasText(classNum)) member.stuNum.substring(1,2).eq(classNum) else null
+
+    private fun genderEq(gender: String?): BooleanExpression? =
+        if(hasText(gender)) member.gender.eq(Gender.valueOf(gender!!)) else null
+
+    private fun roleEq(role: String?): BooleanExpression? =
+        if(hasText(role)) member.roles.any().eq(Role.valueOf(role!!)) else null
+
+    private fun selfStudyStatusEq(selfStudyStatus: SelfStudyStatus?): BooleanExpression? =
+        if(selfStudyStatus != null) member.selfStudyStatus.eq(selfStudyStatus) else null
+
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.dotori.v2.domain.member.domain.repository
+
+import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
+
+class CustomMemberRepositoryImpl : CustomMemberRepository {
+
+
+    override fun search(searchRequestDto: SearchRequestDto): List<Member> {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/MemberRepository.kt
@@ -5,7 +5,7 @@ import com.dotori.v2.domain.member.enums.MassageStatus
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface MemberRepository : JpaRepository<Member, Long> {
+interface MemberRepository : JpaRepository<Member, Long>, CustomMemberRepository {
     fun findByEmail(email: String?): Member?
     fun existsByEmail(email: String): Boolean
     fun findByStuNum(stuNum: String): Member?

--- a/src/main/kotlin/com/dotori/v2/domain/stu_info/service/impl/FindAllMemberServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/stu_info/service/impl/FindAllMemberServiceImpl.kt
@@ -25,4 +25,5 @@ class FindAllMemberServiceImpl(
                     selfStudyStatus = it.selfStudyStatus
                 )
             }
+
 }

--- a/src/main/kotlin/com/dotori/v2/domain/stu_info/service/impl/SearchStudentServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/stu_info/service/impl/SearchStudentServiceImpl.kt
@@ -18,46 +18,22 @@ class SearchStudentServiceImpl(
 
     override fun execute(
         searchRequestDto: SearchRequestDto
-    ): List<SearchStudentListResDto> =
-        getMemberCondition(
-            searchRequestDto,
-            if (searchRequestDto.name != null)
-                memberRepository.findAllByMemberNameStartingWithOrderByStuNumAsc(searchRequestDto.name)
-            else
-                memberRepository.findAllByOrderByStuNumAsc()
-        )
-
-
-    private fun getMemberCondition(
-        searchRequestDto: SearchRequestDto,
-        memberList: List<Member>
     ): List<SearchStudentListResDto> {
 
-        val filterMember = searchRequestDto.run {
-            memberList.asSequence().filter {
-                if (grade != null) it.stuNum.startsWith(grade) else true
-            }.filter {
-                if (classNum != null) it.stuNum.substring(1, 2) == classNum else true
-            }.filter {
-                if (gender != null) it.gender.name == gender else true
-            }.filter {
-                if (role != null) it.roles.getOrNull(0)?.name == role else true
-            }.filter {
-                if(selfStudyStatus == SelfStudyStatus.IMPOSSIBLE) it.selfStudyStatus == selfStudyStatus || it.selfStudyStatus == SelfStudyStatus.CANT
-                else if (selfStudyStatus != null) it.selfStudyStatus == selfStudyStatus else true
-            }.toList()
-        }
+        val members = memberRepository.search(searchRequestDto)
 
-        return filterMember.map {
+        return members.map {
             SearchStudentListResDto(
                 id = it.id,
                 email = it.email,
                 memberName = it.memberName,
                 stuNum = it.stuNum,
                 gender = it.gender,
-                role = it.roles[0],
+                role = it.roles.firstOrNull() ?: ,
                 selfStudyStatus = it.selfStudyStatus
+
             )
         }
     }
+
 }

--- a/src/main/kotlin/com/dotori/v2/domain/stu_info/service/impl/SearchStudentServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/stu_info/service/impl/SearchStudentServiceImpl.kt
@@ -3,6 +3,7 @@ package com.dotori.v2.domain.stu_info.service.impl
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
+import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 import com.dotori.v2.domain.stu_info.presentation.data.res.SearchStudentListResDto
 import com.dotori.v2.domain.stu_info.service.SearchStudentService
@@ -29,7 +30,7 @@ class SearchStudentServiceImpl(
                 memberName = it.memberName,
                 stuNum = it.stuNum,
                 gender = it.gender,
-                role = it.roles.firstOrNull() ?: ,
+                role = it.roles[0],
                 selfStudyStatus = it.selfStudyStatus
 
             )

--- a/src/main/kotlin/com/dotori/v2/global/config/querydsl/QueryDSLConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/querydsl/QueryDSLConfig.kt
@@ -1,0 +1,17 @@
+package com.dotori.v2.global.config.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class QueryDSLConfig(
+    @PersistenceContext
+    private val entityManager: EntityManager
+) {
+
+    @Bean
+    fun jpaQueryFactory() = JPAQueryFactory(entityManager)
+}


### PR DESCRIPTION
💡 개요
유저 동적 검색 서비스 QueryDSL를 적용하여 리팩터링하였습니다.

📃 작업내용
<img width="820" alt="image" src="https://github.com/Team-Ampersand/Dotori-server-V2/assets/105429536/b0197848-d72c-4f33-8326-2bdcfc859db1">
where 조건절에 바로 BooleanExpression을 넣을 수도 있었지만 이번에는
더욱 직관적이고 조립하여 재사용성도 높여지는 where 조건문에 들어가는 함수를 분리해서 작성했습니다.

🔀 변경사항
- `SearchStudentServiceImpl` 비즈니스로직
- `CustomMemberRepository`쿼리문 작성

🙋‍♂️ 질문사항
궁금한게 검색조건을 받을때 role, gender는 왜 String?으로 받는지 궁금합니다. 그냥 Enum으로 받아도 상관 없을거 같은데..

🍴 사용방법

🎸 기타
향후 자습신청 멤버 검색 api도 바로 적용하겠습니다 QueryDSL