### PR TITLE
237 feat/get self study querydsl

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @louis7308 @Huuuunee @dolong2 @uuuuuuuk @cutehanchankyo
+* @louis7308 @Huuuunee @dolong2 @uuuuuuuk @cutehanchankyo @esperar

--- a/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepository.kt
@@ -6,5 +6,5 @@ import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 
 interface CustomMemberRepository {
     fun search(searchRequestDto: SearchRequestDto): List<Member>
-    fun selfStudySearch(selfStudySearchReqDto: SelfStudySearchReqDto): List<Member>
+    fun searchSelfStudyMember(selfStudySearchReqDto: SelfStudySearchReqDto): List<Member>
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepository.kt
@@ -1,8 +1,10 @@
 package com.dotori.v2.domain.member.domain.repository
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.self_study.presentation.dto.req.SelfStudySearchReqDto
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 
 interface CustomMemberRepository {
     fun search(searchRequestDto: SearchRequestDto): List<Member>
+    fun selfStudySearch(selfStudySearchReqDto: SelfStudySearchReqDto): List<Member>
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepositoryImpl.kt
@@ -31,7 +31,7 @@ class CustomMemberRepositoryImpl(
             .fetch()
     }
 
-    override fun selfStudySearch(selfStudySearchReqDto: SelfStudySearchReqDto): List<Member> {
+    override fun searchSelfStudyMember(selfStudySearchReqDto: SelfStudySearchReqDto): List<Member> {
         return queryFactory.selectFrom(member)
             .where(
                 nameEq(selfStudySearchReqDto.name),

--- a/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.dotori.v2.domain.member.domain.entity.QMember.member
 import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
+import com.dotori.v2.domain.self_study.presentation.dto.req.SelfStudySearchReqDto
 import com.dotori.v2.domain.stu_info.presentation.data.req.SearchRequestDto
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
@@ -25,6 +26,18 @@ class CustomMemberRepositoryImpl(
                 genderEq(searchRequestDto.gender),
                 roleEq(searchRequestDto.role),
                 selfStudyStatusEq(searchRequestDto.selfStudyStatus)
+            )
+            .orderBy(member.stuNum.asc())
+            .fetch()
+    }
+
+    override fun selfStudySearch(selfStudySearchReqDto: SelfStudySearchReqDto): List<Member> {
+        return queryFactory.selectFrom(member)
+            .where(
+                nameEq(selfStudySearchReqDto.name),
+                gradeEq(selfStudySearchReqDto.grade),
+                classNumEq(selfStudySearchReqDto.classNum),
+                genderEq(selfStudySearchReqDto.gender)
             )
             .orderBy(member.stuNum.asc())
             .fetch()

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/service/impl/GetSelfStudyByStuNumAndNameServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/service/impl/GetSelfStudyByStuNumAndNameServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.dotori.v2.domain.self_study.service.impl
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.self_study.domain.repository.SelfStudyRepository
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyMemberListResDto
 import com.dotori.v2.domain.self_study.presentation.dto.res.SelfStudyMemberResDto
@@ -12,28 +13,15 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true, rollbackFor = [Exception::class])
 class GetSelfStudyByStuNumAndNameServiceImpl(
-    private val selfStudyRepository: SelfStudyRepository,
+    private val memberRepository: MemberRepository
 ) : GetSelfStudyByStuNumAndNameService {
     override fun execute(searchRequestDto: SelfStudySearchReqDto): SelfStudyMemberListResDto {
-        val memberList = selfStudyRepository.findAllOrderByCreatedDateAsc()
-            .filter {
-                if(searchRequestDto.name != null) it.member.memberName == searchRequestDto.name else true
+        val members = memberRepository.searchSelfStudyMember(searchRequestDto)
+
+        return SelfStudyMemberListResDto(
+            members.mapIndexed{index, it ->
+                SelfStudyMemberResDto(index + 1L, it)
             }
-            .map { it.member }
-        return getMemberCondition(searchRequestDto, memberList)
-    }
-
-    private fun getMemberCondition(searchRequestDto: SelfStudySearchReqDto, memberList: List<Member>): SelfStudyMemberListResDto {
-        val filterMember = searchRequestDto.run {
-            memberList.filter {
-                if (grade != null) it.stuNum.startsWith(grade) else true
-            }.filter {
-                if (classNum != null) it.stuNum.substring(1, 2) == classNum else true
-            }.filter {
-                if (gender != null) it.gender.name == gender else true
-            }.toList()
-        }
-
-        return SelfStudyMemberListResDto(filterMember.mapIndexed{index, it -> SelfStudyMemberResDto(index + 1L, it) })
+        )
     }
 }


### PR DESCRIPTION
💡 개요
자습 신청 멤버 동적 검색 서비스에도 QueryDSL을 적용했습니다.
조건절을 함수로 분리했기때문에 self study member를 찾는 쿼리도 전에 만들어놓은 함수를 이용해 개발했습니다.

📃 작업내용
![image](https://github.com/Team-Ampersand/Dotori-server-V2/assets/105429536/00e69fbc-2fbe-4470-8586-8c3d6649b077)

🔀 변경사항

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타