### PR TITLE
🔨  ::  243 - 회원탈퇴할때 이메일, 비밀번호 입력 안받게 수정

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
@@ -22,7 +22,7 @@ class MemberController(
         logoutService.execute()
             .run { ResponseEntity.ok().build() }
 
-    @PostMapping("/withdrawal")
+    @DeleteMapping("/withdrawal")
     fun withdrawal(): ResponseEntity<Void> =
         withdrawalService.execute()
             .run { ResponseEntity.ok().build() }

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
@@ -23,8 +23,8 @@ class MemberController(
             .run { ResponseEntity.ok().build() }
 
     @PostMapping("/withdrawal")
-    fun withdrawal(@Valid @RequestBody withdrawalReqDto: WithdrawalReqDto): ResponseEntity<Void> =
-        withdrawalService.execute(withdrawalReqDto)
+    fun withdrawal(): ResponseEntity<Void> =
+        withdrawalService.execute()
             .run { ResponseEntity.ok().build() }
 
     @PatchMapping("/password")

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/WithdrawalService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/WithdrawalService.kt
@@ -1,7 +1,5 @@
 package com.dotori.v2.domain.member.service
 
-import com.dotori.v2.domain.member.presentation.data.req.WithdrawalReqDto
-
 interface WithdrawalService {
-    fun execute(withdrawalReqDto: WithdrawalReqDto)
+    fun execute()
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/WithdrawalServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/WithdrawalServiceImpl.kt
@@ -15,21 +15,11 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(rollbackFor = [Exception::class])
 class WithdrawalServiceImpl(
     private val memberRepository: MemberRepository,
-    private val passwordEncoder: PasswordEncoder,
     private val userUtil: UserUtil,
 ) : WithdrawalService {
-    override fun execute(withdrawalReqDto: WithdrawalReqDto) {
+    override fun execute() {
         val currentUser = userUtil.fetchCurrentUser()
 
-        val member = memberRepository.findByEmail(withdrawalReqDto.email)
-            ?: throw MemberNotFoundException()
-
-        if (!passwordEncoder.matches(withdrawalReqDto.password, member.password))
-            throw PasswordMismatchException()
-
-        if (currentUser != member)
-            throw MemberNotSameException()
-
-        memberRepository.delete(member)
+        memberRepository.delete(currentUser)
     }
 }

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/WithdrawalControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/WithdrawalControllerTest.kt
@@ -20,11 +20,10 @@ class WithdrawalControllerTest : BehaviorSpec({
 
     given("요청이 들어오면") {
         `when`("is received") {
-            val reqDto = WithdrawalReqDto("test@gsm.hs.kr", "1234")
-            every { withdrawalService.execute(reqDto) } returns Unit
-            val response = authController.withdrawal(reqDto)
+            every { withdrawalService.execute() } returns Unit
+            val response = authController.withdrawal()
             then("서비스가 한번은 실행되어야 함") {
-                verify(exactly = 1) { withdrawalService.execute(reqDto) }
+                verify(exactly = 1) { withdrawalService.execute() }
             }
             then("response status should be ok") {
                 response.statusCode shouldBe HttpStatus.OK

--- a/src/test/kotlin/com/dotori/v2/domain/member/service/WithdrawalServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/service/WithdrawalServiceTest.kt
@@ -21,8 +21,7 @@ import java.util.*
 class WithdrawalServiceTest : BehaviorSpec({
     val memberRepository = mockk<MemberRepository>()
     val userUtil = mockk<UserUtil>()
-    val passwordEncoder = mockk<PasswordEncoder>()
-    val withdrawalServiceImpl = WithdrawalServiceImpl(memberRepository, passwordEncoder, userUtil)
+    val withdrawalServiceImpl = WithdrawalServiceImpl(memberRepository, userUtil)
     given("유저와 dto가 주어지고") {
         val testMember = Member(
             memberName = "test",
@@ -34,48 +33,11 @@ class WithdrawalServiceTest : BehaviorSpec({
             ruleViolation = mutableListOf()
         )
         val request = WithdrawalReqDto("test@gsm.hs.kr", "1234")
-        init(userUtil, testMember, memberRepository, request, passwordEncoder)
+        init(userUtil, testMember, memberRepository, request)
         `when`("서비스를 실행하면") {
-            withdrawalServiceImpl.execute(request)
+            withdrawalServiceImpl.execute()
             then("delete가 실행되어야함") {
                 verify(exactly = 1) { memberRepository.delete(testMember) }
-            }
-        }
-        `when`("유저를 찾을 수 없을때") {
-            every { memberRepository.findByEmail(request.email) } returns null
-            then("MemberNotFoundException이 터져야함") {
-                shouldThrow<MemberNotFoundException> {
-                    withdrawalServiceImpl.execute(request)
-                }
-            }
-        }
-        init(userUtil, testMember, memberRepository, request, passwordEncoder)
-        `when`("패스워드가 일치하지 않을때") {
-            every { passwordEncoder.matches(request.password, testMember.password) } returns false
-            then("PasswordMismatchException이 터져야함") {
-                shouldThrow<PasswordMismatchException> {
-                    withdrawalServiceImpl.execute(request)
-                }
-            }
-        }
-        init(userUtil, testMember, memberRepository, request, passwordEncoder)
-        `when`("현재 로그인된 유저와 요청에서 가져온 유저가 일치하지 않을때") {
-            val otherMember = Member(
-                0,
-                "test1",
-                "0000",
-                "other@gsm.hs.kr",
-                "test1",
-                Gender.MAN,
-                Collections.singletonList(Role.ROLE_MEMBER),
-                ruleViolation = mutableListOf()
-            )
-            every { memberRepository.findByEmail(request.email) } returns otherMember
-            every { passwordEncoder.matches(request.password, otherMember.password) } returns true
-            then("MemberNotSameException이 터져야함") {
-                shouldThrow<MemberNotSameException> {
-                    withdrawalServiceImpl.execute(request)
-                }
             }
         }
     }
@@ -86,10 +48,8 @@ private fun init(
     testMember: Member,
     memberRepository: MemberRepository,
     request: WithdrawalReqDto,
-    passwordEncoder: PasswordEncoder
 ) {
     every { userUtil.fetchCurrentUser() } returns testMember
     every { memberRepository.findByEmail(request.email) } returns testMember
-    every { passwordEncoder.matches(request.password, testMember.password) } returns true
     every { memberRepository.delete(testMember) } returns Unit
 }


### PR DESCRIPTION
💡 개요
* @baekteun  탈퇴할때 이메일, 비번 입력 앋받게 수정해주라 하셔서 작업함

📃 작업내용
* UserController.withdrawal(), WithdrawalService에서 이메일, 비밀번호 입력 안받게 수정

🔀 변경사항

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타