### PR TITLE
🔀 :: 프로필 이미지 수정 api

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/main_page/presentation/dto/res/PersonalInfoResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/main_page/presentation/dto/res/PersonalInfoResDto.kt
@@ -7,7 +7,8 @@ data class PersonalInfoResDto(
     val id: Long,
     val stuNum: String,
     val name: String,
-    val gender: Gender
+    val gender: Gender,
+    val profileImage: String?
 ) {
-    constructor(member: Member) : this(id = member.id, stuNum = member.stuNum, name = member.memberName, gender = member.gender)
+    constructor(member: Member) : this(id = member.id, stuNum = member.stuNum, name = member.memberName, gender = member.gender, profileImage = member.profileImage)
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
@@ -13,7 +13,8 @@ class MemberController(
     private val logoutService: LogoutService,
     private val withdrawalService: WithdrawalService,
     private val changeAuthPasswordService: ChangeAuthPasswordService,
-    private val uploadProfileImageService: UploadProfileImageService
+    private val uploadProfileImageService: UploadProfileImageService,
+    private val updateProfileImageService: UpdateProfileImageService
 ) {
     @DeleteMapping("/logout")
     fun logout(): ResponseEntity<Void> =
@@ -33,6 +34,11 @@ class MemberController(
     @PostMapping("/profileImage")
     fun uploadProfileImage(@RequestParam(value = "images") multipartFiles: MultipartFile?): ResponseEntity<Void> =
         uploadProfileImageService.execute(multipartFiles)
+            .run { ResponseEntity.ok().build() }
+
+    @PatchMapping("/profileImage")
+    fun updateProfileImage(@RequestParam(value = "images") multipartFiles: MultipartFile?): ResponseEntity<Void> =
+        updateProfileImageService.execute(multipartFiles)
             .run { ResponseEntity.ok().build() }
 
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/UpdateProfileImageService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/UpdateProfileImageService.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.domain.member.service
+
+import org.springframework.web.multipart.MultipartFile
+
+interface UpdateProfileImageService {
+    fun execute(multipartFiles: MultipartFile?)
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -1,0 +1,27 @@
+package com.dotori.v2.domain.member.service.impl
+
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.service.UpdateProfileImageService
+import com.dotori.v2.global.thirdparty.aws.s3.S3Service
+import com.dotori.v2.global.util.UserUtil
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class UpdateProfileImageServiceImpl(
+    private val memberRepository: MemberRepository,
+    private val userUtil: UserUtil,
+    private val s3Service: S3Service,
+): UpdateProfileImageService {
+    override fun execute(multipartFiles: MultipartFile?) {
+        val member = userUtil.fetchCurrentUser()
+        var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
+        uploadFile = "https://dotori-s3.s3.ap-northeast-2.amazonaws.com/img/$uploadFile"
+        s3Service.deleteFile(member.profileImage!!)
+        member.updateProfileImage(uploadFile)
+            .let { memberRepository.save(it) }
+
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -18,7 +18,6 @@ class UpdateProfileImageServiceImpl(
     override fun execute(multipartFiles: MultipartFile?) {
         val member = userUtil.fetchCurrentUser()
         var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
-        uploadFile = "https://dotori-s3.s3.ap-northeast-2.amazonaws.com/img/$uploadFile"
         s3Service.deleteFile(member.profileImage!!)
         member.updateProfileImage(uploadFile)
             .let { memberRepository.save(it) }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -18,10 +18,9 @@ class UploadProfileImageServiceImpl(
 ) : UploadProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
-        val uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
-
+        var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
+        uploadFile = "https://dotori-s3.s3.ap-northeast-2.amazonaws.com/img/$uploadFile"
         member.updateProfileImage(uploadFile)
             .let { memberRepository.save(it) }
-
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -15,11 +15,10 @@ class UploadProfileImageServiceImpl(
     private val memberRepository: MemberRepository,
     private val userUtil: UserUtil,
     private val s3Service: S3Service,
-) : UploadProfileImageService {
+): UploadProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
         var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
-        uploadFile = "https://dotori-s3.s3.ap-northeast-2.amazonaws.com/img/$uploadFile"
         member.updateProfileImage(uploadFile)
             .let { memberRepository.save(it) }
     }

--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/aws/s3/S3ServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/aws/s3/S3ServiceImpl.kt
@@ -20,6 +20,9 @@ class S3ServiceImpl(
     @Value("\${cloud.aws.s3.bucket}")
     private val bucket: String? = null
 
+    @Value("\${cloud.aws.s3.url}")
+    private val url: String = ""
+
     override fun uploadListFile(multipartFiles: List<MultipartFile>?): List<String> {
         val fileNameList = ArrayList<String>()
 
@@ -37,7 +40,7 @@ class S3ServiceImpl(
             } catch (e: IOException) {
                 throw IllegalStateException("파일 업로드에 실패했습니다.")
             }
-            fileNameList.add(fileName)
+            fileNameList.add(url+fileName)
         }
         return fileNameList
     }
@@ -58,7 +61,7 @@ class S3ServiceImpl(
                 PutObjectRequest(bucket, fileName, multipartFile.inputStream, objectMetadata)
                     .withCannedAcl(CannedAccessControlList.PublicRead)
             )
-            return fileName
+            return url+fileName
         } catch (e: IOException) {
             throw IllegalStateException("파일 업로드에 실패했습니다.")
         }

--- a/src/test/kotlin/com/dotori/v2/domain/main_page/controller/GetPersonalInfoControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/main_page/controller/GetPersonalInfoControllerTest.kt
@@ -17,7 +17,7 @@ class GetPersonalInfoControllerTest : BehaviorSpec({
 
     given("요청이 들어오면") {
         `when`("is received") {
-            val target = PersonalInfoResDto(1, "test", "test", Gender.MAN)
+            val target = PersonalInfoResDto(1, "test", "test", Gender.MAN, null)
             every { getPersonalInfoService.execute() } returns target
             val response = controller.getPersonalInfo()
             then("서비스가 한번은 실행되어야 함") {

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/ChangePasswordControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/ChangePasswordControllerTest.kt
@@ -15,7 +15,8 @@ class ChangePasswordControllerTest : BehaviorSpec({
     val withdrawalService = mockk<WithdrawalService>()
     val changePasswordService = mockk<ChangeAuthPasswordService>()
     val uploadProfileImageService = mockk<UploadProfileImageService>()
-    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService)
+    val updateProfileImageService = mockk<UpdateProfileImageService>()
+    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService, updateProfileImageService)
 
     given("요청이 들어오면") {
         `when`("is received") {

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/LogoutControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/LogoutControllerTest.kt
@@ -15,7 +15,8 @@ class LogoutControllerTest : BehaviorSpec({
     val withdrawalService = mockk<WithdrawalService>()
     val changePasswordService = mockk<ChangeAuthPasswordService>()
     val uploadProfileImageService = mockk<UploadProfileImageService>()
-    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService)
+    val updateProfileImageService = mockk<UpdateProfileImageService>()
+    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService, updateProfileImageService)
 
     given("요청이 들어오면") {
         `when`("is received") {

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/WithdrawalControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/WithdrawalControllerTest.kt
@@ -17,7 +17,8 @@ class WithdrawalControllerTest : BehaviorSpec({
     val withdrawalService = mockk<WithdrawalService>()
     val changePasswordService = mockk<ChangeAuthPasswordService>()
     val uploadProfileImageService = mockk<UploadProfileImageService>()
-    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService)
+    val updateProfileImageService = mockk<UpdateProfileImageService>()
+    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService, updateProfileImageService)
 
     given("요청이 들어오면") {
         `when`("is received") {


### PR DESCRIPTION
💡 개요
+ 프로필 이미지 수정하는 api를 구현하겠습니다.

📃 작업내용
+ 프로필 이미지 수정하는 service를 구현하겠습니다.
+ 프로필 이미지 수정하는 api를 추가하였습니다.
+ home 화면에서 반환되는 유저정보에 profileImage필드를 추가하였습니다.
+ db에 프로필이미지 저장할때 string이 아닌 이미지 url로 저장하도록 수정하였습니다.