### PR TITLE
🔀 :: 프로필 이미지 삭제 api

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/massage/presentation/dto/res/MassageMemberResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/massage/presentation/dto/res/MassageMemberResDto.kt
@@ -8,7 +8,8 @@ data class MassageMemberResDto(
     val id: Long,
     val stuNum: String,
     val memberName: String,
-    val gender: Gender
+    val gender: Gender,
+    val profileUrl: String?
 ) {
-    constructor(rank: Long, member: Member) : this(rank = rank, id = member.id, stuNum = member.stuNum, memberName = member.memberName, gender = member.gender)
+    constructor(rank: Long, member: Member) : this(rank = rank, id = member.id, stuNum = member.stuNum, memberName = member.memberName, gender = member.gender, profileUrl = member.profileImage)
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
@@ -33,12 +33,12 @@ class MemberController(
             .run { ResponseEntity.ok().build() }
 
     @PostMapping("/profileImage")
-    fun uploadProfileImage(@RequestParam(value = "images") multipartFiles: MultipartFile?): ResponseEntity<Void> =
+    fun uploadProfileImage(@RequestParam(value = "image") multipartFiles: MultipartFile?): ResponseEntity<Void> =
         uploadProfileImageService.execute(multipartFiles)
             .run { ResponseEntity.ok().build() }
 
     @PatchMapping("/profileImage")
-    fun updateProfileImage(@RequestParam(value = "images") multipartFiles: MultipartFile?): ResponseEntity<Void> =
+    fun updateProfileImage(@RequestParam(value = "image") multipartFiles: MultipartFile?): ResponseEntity<Void> =
         updateProfileImageService.execute(multipartFiles)
             .run { ResponseEntity.ok().build() }
 

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
@@ -45,6 +45,6 @@ class MemberController(
     @DeleteMapping("/profileImage")
     fun deleteProfileImage(): ResponseEntity<Void> =
         deleteProfileImageService.execute()
-            .run { ResponseEntity.noContent().build() }
+            .run { ResponseEntity.ok().build() }
 
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
@@ -14,7 +14,8 @@ class MemberController(
     private val withdrawalService: WithdrawalService,
     private val changeAuthPasswordService: ChangeAuthPasswordService,
     private val uploadProfileImageService: UploadProfileImageService,
-    private val updateProfileImageService: UpdateProfileImageService
+    private val updateProfileImageService: UpdateProfileImageService,
+    private val deleteProfileImageService: DeleteProfileImageService
 ) {
     @DeleteMapping("/logout")
     fun logout(): ResponseEntity<Void> =
@@ -40,5 +41,10 @@ class MemberController(
     fun updateProfileImage(@RequestParam(value = "images") multipartFiles: MultipartFile?): ResponseEntity<Void> =
         updateProfileImageService.execute(multipartFiles)
             .run { ResponseEntity.ok().build() }
+
+    @DeleteMapping("/profileImage")
+    fun deleteProfileImage(): ResponseEntity<Void> =
+        deleteProfileImageService.execute()
+            .run { ResponseEntity.noContent().build() }
 
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/DeleteProfileImageService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/DeleteProfileImageService.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.domain.member.service
+
+interface DeleteProfileImageService {
+
+    fun execute()
+
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/DeleteProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/DeleteProfileImageServiceImpl.kt
@@ -1,0 +1,24 @@
+package com.dotori.v2.domain.member.service.impl
+
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.service.DeleteProfileImageService
+import com.dotori.v2.global.thirdparty.aws.s3.S3Service
+import com.dotori.v2.global.util.UserUtil
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class DeleteProfileImageServiceImpl(
+    private val memberRepository: MemberRepository,
+    private val userUtil: UserUtil,
+    private val s3Service: S3Service
+) : DeleteProfileImageService {
+
+    override fun execute() {
+        val member = userUtil.fetchCurrentUser()
+        s3Service.deleteFile(member.profileImage!!)
+        memberRepository.save(member.updateProfileImage(null))
+    }
+
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -14,7 +14,7 @@ import org.springframework.web.multipart.MultipartFile
 class UploadProfileImageServiceImpl(
     private val memberRepository: MemberRepository,
     private val userUtil: UserUtil,
-    private val s3Service: S3Service,
+    private val s3Service: S3Service
 ): UploadProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()

--- a/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/dto/res/SelfStudyMemberResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/self_study/presentation/dto/res/SelfStudyMemberResDto.kt
@@ -9,7 +9,8 @@ data class SelfStudyMemberResDto(
     val stuNum: String,
     val memberName: String,
     val gender: Gender,
-    val selfStudyCheck: Boolean
+    val selfStudyCheck: Boolean,
+    val profileUrl: String?
 ) {
-    constructor(rank: Long, member: Member) : this(rank = rank, id = member.id, stuNum = member.stuNum, memberName = member.memberName, gender = member.gender, selfStudyCheck = member.selfStudyCheck)
+    constructor(rank: Long, member: Member) : this(rank = rank, id = member.id, stuNum = member.stuNum, memberName = member.memberName, gender = member.gender, selfStudyCheck = member.selfStudyCheck, profileUrl = member.profileImage)
 }

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/ChangePasswordControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/ChangePasswordControllerTest.kt
@@ -16,7 +16,8 @@ class ChangePasswordControllerTest : BehaviorSpec({
     val changePasswordService = mockk<ChangeAuthPasswordService>()
     val uploadProfileImageService = mockk<UploadProfileImageService>()
     val updateProfileImageService = mockk<UpdateProfileImageService>()
-    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService, updateProfileImageService)
+    val deleteProfileImageService = mockk<DeleteProfileImageService>()
+    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService, updateProfileImageService, deleteProfileImageService)
 
     given("요청이 들어오면") {
         `when`("is received") {

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/LogoutControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/LogoutControllerTest.kt
@@ -16,7 +16,8 @@ class LogoutControllerTest : BehaviorSpec({
     val changePasswordService = mockk<ChangeAuthPasswordService>()
     val uploadProfileImageService = mockk<UploadProfileImageService>()
     val updateProfileImageService = mockk<UpdateProfileImageService>()
-    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService, updateProfileImageService)
+    val deleteProfileImageService = mockk<DeleteProfileImageService>()
+    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService, updateProfileImageService, deleteProfileImageService)
 
     given("요청이 들어오면") {
         `when`("is received") {

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/WithdrawalControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/WithdrawalControllerTest.kt
@@ -18,7 +18,8 @@ class WithdrawalControllerTest : BehaviorSpec({
     val changePasswordService = mockk<ChangeAuthPasswordService>()
     val uploadProfileImageService = mockk<UploadProfileImageService>()
     val updateProfileImageService = mockk<UpdateProfileImageService>()
-    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService, updateProfileImageService)
+    val deleteProfileImageService = mockk<DeleteProfileImageService>()
+    val authController = MemberController(logoutService, withdrawalService, changePasswordService, uploadProfileImageService, updateProfileImageService, deleteProfileImageService)
 
     given("요청이 들어오면") {
         `when`("is received") {


### PR DESCRIPTION
💡 개요
+ 프로필 이미지 삭제 기능 구현하였습니다.
📃 작업내용
+ 프로필 이미지 삭제 service 구현하였습니다.
+ 프로필 이미지 삭제 api 구현하였습니다.
+ 안마의자, 자습 list 필드 추가하였습니다.
🔀 변경사항
+ 안마의자, 자습 list 필드에 profileUrl을 추가하였습니다.
+ param이름을 단일형으로 변경하였습니다.
🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타