### PR TITLE
🔀 :: 262-youtube api 사용해서 데이터 불러오기

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
 
 dependencies {
     implementation(Dependencies.SPRING_JPA)
+    implementation(Dependencies.SPRING_OPEN_FEIGN)
     implementation(Dependencies.SPRING_REDIS)
     implementation(Dependencies.MAIL)
     implementation(Dependencies.SECURITY)
@@ -48,6 +49,10 @@ dependencies {
     implementation(Dependencies.QUERY_DSL)
     implementation(Dependencies.QUERY_DSL_APT)
     kapt(Dependencies.QUERY_DSL_APT)
+    implementation(Dependencies.GOOGLE_API_CLIENT)
+    implementation(Dependencies.GOOGLE_OAUTH_CLIENT)
+    implementation(Dependencies.YOUTUBE_ANALYTICS)
+    implementation(Dependencies.GOOGLE_API_SERVICE)
 }
 
 tasks.withType<KotlinCompile> {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Dependencies {
     const val VALIDATION = "org.springframework.boot:spring-boot-starter-validation"
     const val WEB = "org.springframework.boot:spring-boot-starter-web"
     const val SPRING_CLOUD = "org.springframework.cloud:spring-cloud-starter-aws:${DependencyVersions.SPRING_CLOUD_VERSION}"
-
+    const val SPRING_OPEN_FEIGN = "org.springframework.cloud:spring-cloud-starter-openfeign:${DependencyVersions.SPRING_CLOUD_OPEN_FEIGN}"
 
     // kotlin
     const val KOTLIN_JACKSON = "com.fasterxml.jackson.module:jackson-module-kotlin"
@@ -45,5 +45,11 @@ object Dependencies {
     // querydsl
     const val QUERY_DSL = "com.querydsl:querydsl-jpa:${DependencyVersions.QUERY_DSL_VERSION}"
     const val QUERY_DSL_APT = "com.querydsl:querydsl-apt:${DependencyVersions.QUERY_DSL_APT_VERSION}:jpa"
+
+    // youtube
+    const val GOOGLE_API_CLIENT = "com.google.api-client:google-api-client:${DependencyVersions.GOOGLE_API_CLIENT_VERSION}"
+    const val GOOGLE_OAUTH_CLIENT = "com.google.oauth-client:google-oauth-client-jetty:${DependencyVersions.GOOGLE_OAUTH_VERSION}"
+    const val YOUTUBE_ANALYTICS = "com.google.apis:google-api-services-youtubeAnalytics:${DependencyVersions.YOUTUBE_ANALYTICS_VERSION}"
+    const val GOOGLE_API_SERVICE = "com.google.apis:google-api-services-youtube:${DependencyVersions.GOOGLE_API_SERVICE_VERSION}"
 
 }

--- a/buildSrc/src/main/kotlin/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersions.kt
@@ -2,6 +2,7 @@ object DependencyVersions {
 
     // spring
     const val SPRING_CLOUD_VERSION = "2.2.6.RELEASE"
+    const val SPRING_CLOUD_OPEN_FEIGN = "3.1.8"
 
     // kotest
     const val KOTEST_RUNNER_VERSION = "5.5.5"
@@ -24,4 +25,10 @@ object DependencyVersions {
     // querydsl
     const val QUERY_DSL_VERSION = "5.0.0"
     const val QUERY_DSL_APT_VERSION = "5.0.0"
+
+    // youtube
+    const val GOOGLE_API_CLIENT_VERSION = "1.31.1"
+    const val GOOGLE_OAUTH_VERSION = "1.23.0"
+    const val YOUTUBE_ANALYTICS_VERSION = "v2-rev16-1.23.0"
+    const val GOOGLE_API_SERVICE_VERSION = "v3-rev20210915-1.32.1"
 }

--- a/src/main/kotlin/com/dotori/v2/V2Application.kt
+++ b/src/main/kotlin/com/dotori/v2/V2Application.kt
@@ -3,11 +3,13 @@ package com.dotori.v2
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.scheduling.annotation.EnableScheduling
 import java.util.*
 import javax.annotation.PostConstruct
 
 @EnableScheduling
+@EnableFeignClients
 @SpringBootApplication
 class V2Application{
 	val log = LoggerFactory.getLogger(this::class.java.name)!!

--- a/src/main/kotlin/com/dotori/v2/domain/music/domain/entity/Music.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/domain/entity/Music.kt
@@ -4,7 +4,6 @@ import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.global.entity.BaseTimeEntity
 import javax.persistence.*
 
-
 @Entity
 @Table(name = "music")
 class Music(
@@ -14,6 +13,10 @@ class Music(
     val id: Long = 0,
     @Column(name = "music_url", nullable = false)
     val url: String,
+    @Column(name = "music_title", nullable = false)
+    val title: String,
+    @Column(name = "music_thumbnail", nullable = false)
+    val thumbnail: String,
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     val member: Member

--- a/src/main/kotlin/com/dotori/v2/domain/music/presentation/data/res/MusicResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/presentation/data/res/MusicResDto.kt
@@ -5,6 +5,8 @@ import java.time.LocalDateTime
 data class MusicResDto(
     val id: Long,
     val url: String,
+    val title: String,
+    val thumbnail: String,
     val username: String,
     val email: String,
     val createdTime: LocalDateTime,

--- a/src/main/kotlin/com/dotori/v2/domain/music/service/impl/FindMusicsServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/service/impl/FindMusicsServiceImpl.kt
@@ -25,6 +25,8 @@ class FindMusicsServiceImpl(
         MusicResDto(
             id = music.id,
             url = music.url,
+            title = music.title,
+            thumbnail = music.thumbnail,
             username = music.member.memberName,
             email = music.member.email,
             createdTime = music.createdDate,

--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/data/dto/VideoItem.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/data/dto/VideoItem.kt
@@ -1,0 +1,5 @@
+package com.dotori.v2.global.thirdparty.youtube.data.dto
+
+data class VideoItem(
+    val snippet: VideoSnippet
+)

--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/data/dto/VideoSnippet.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/data/dto/VideoSnippet.kt
@@ -1,0 +1,5 @@
+package com.dotori.v2.global.thirdparty.youtube.data.dto
+
+data class VideoSnippet(
+    val title: String
+)

--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/data/dto/YouTubeVideoInfo.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/data/dto/YouTubeVideoInfo.kt
@@ -1,0 +1,5 @@
+package com.dotori.v2.global.thirdparty.youtube.data.dto
+
+data class YouTubeVideoInfo(
+    val items: List<VideoItem>
+)

--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/data/res/YoutubeResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/data/res/YoutubeResDto.kt
@@ -1,0 +1,6 @@
+package com.dotori.v2.global.thirdparty.youtube.data.res
+
+data class YoutubeResDto(
+    val title: String,
+    val thumbnail: String,
+)

--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/feign/YouTubeFeignClient.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/feign/YouTubeFeignClient.kt
@@ -1,0 +1,20 @@
+package com.dotori.v2.global.thirdparty.youtube.feign
+
+import com.dotori.v2.global.thirdparty.youtube.data.dto.YouTubeVideoInfo
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(name = "youtube", url = "https://www.googleapis.com/youtube/v3/videos")
+@Component
+interface YouTubeFeignClient {
+
+    @GetMapping
+    fun getVideoInfo(
+        @RequestParam("part") part: String,
+        @RequestParam("id") id: String,
+        @RequestParam("key") key: String
+    ): YouTubeVideoInfo
+
+}

--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/service/YoutubeService.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/service/YoutubeService.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.global.thirdparty.youtube.service
+
+import com.dotori.v2.global.thirdparty.youtube.data.res.YoutubeResDto
+
+interface YoutubeService {
+    fun getYoutubeInfo(url: String): YoutubeResDto
+}

--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/service/impl/YoutubeServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/service/impl/YoutubeServiceImpl.kt
@@ -1,0 +1,39 @@
+package com.dotori.v2.global.thirdparty.youtube.service.impl
+
+import com.dotori.v2.global.thirdparty.youtube.service.YoutubeService
+import com.dotori.v2.global.thirdparty.youtube.data.res.YoutubeResDto
+import com.dotori.v2.global.thirdparty.youtube.feign.YouTubeFeignClient
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class YoutubeServiceImpl(
+    private val youtubeFeignClient: YouTubeFeignClient
+) : YoutubeService {
+    @Value("\${youtube.api-key}")
+    private val apiKey: String = ""
+
+    override fun getYoutubeInfo(url: String): YoutubeResDto {
+        val videoId = extractVideoId(url)
+        val videoInfo = youtubeFeignClient.getVideoInfo(
+            part = "snippet",
+            id = videoId,
+            key = apiKey,
+        )
+        return YoutubeResDto(
+            title = videoInfo.items[0].snippet.title,
+            thumbnail = "https://img.youtube.com/vi/${videoId}/0.jpg"
+        )
+    }
+
+    private fun extractVideoId(videoUrl: String): String {
+        val startIndex = videoUrl.indexOf("v=")
+        if (startIndex != -1) {
+            val endIndex = videoUrl.indexOfAny(charArrayOf('&', 't'), startIndex)
+            return videoUrl.substring(startIndex + 2, endIndex.takeIf { it != -1 } ?: videoUrl.length)
+        }
+        return ""
+    }
+}

--- a/src/test/kotlin/com/dotori/v2/domain/music/util/MusicUtil.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/music/util/MusicUtil.kt
@@ -9,8 +9,10 @@ class MusicUtil {
         fun createMusic(
             id: Long = 0,
             url: String = "https://www.test.url",
+            title: String = "title",
+            thumbnail: String = "thumbnail",
             member: Member = MemberUtil.createMember()
-        ) = Music(id, url, member)
+        ) = Music(id, url, title, thumbnail, member)
     }
 
 }


### PR DESCRIPTION
💡 개요
+ 서버에서 youtube-api를 불러오는 작업을 하였습니다.

📃 작업내용
+ Music엔티티에 title, thumbnail 필드를 추가하였습니다.
+ FeignClient를 사용해서 youtube api를 불러왔습니다.
+ 기상음악 신청 리스트를 서버에서 반환할때 title과 thumbnail도 함께 반환되게 수정하였습니다.