### PR TITLE
기존 회원가입, 이메일등 유저 기능을 복구

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/presentation/AuthController.kt
@@ -3,12 +3,12 @@ package com.dotori.v2.domain.auth.presentation
 import com.dotori.v2.domain.auth.util.AuthConverter
 import com.dotori.v2.domain.auth.presentation.data.req.SignInGAuthReqDto
 import com.dotori.v2.domain.auth.presentation.data.req.SignInEmailAndPasswordReqDto
+import com.dotori.v2.domain.auth.presentation.data.req.SignUpReqDto
 import com.dotori.v2.domain.auth.presentation.data.res.RefreshResDto
 import com.dotori.v2.domain.auth.presentation.data.res.SignInResDto
-import com.dotori.v2.domain.auth.service.LogoutService
-import com.dotori.v2.domain.auth.service.RefreshTokenService
-import com.dotori.v2.domain.auth.service.SignInEmailAndPasswordService
-import com.dotori.v2.domain.auth.service.SignInGAuthService
+import com.dotori.v2.domain.auth.service.*
+import com.dotori.v2.domain.member.presentation.data.req.NoAuthNewPasswordReqDto
+import com.dotori.v2.domain.member.service.ChangePasswordService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
@@ -16,19 +16,25 @@ import javax.validation.Valid
 @RestController
 @RequestMapping("/v2/auth")
 class AuthController (
+    private val signUpService: SignUpService,
     private val signInGAuthService: SignInGAuthService,
     private val signInEmailAndPasswordService: SignInEmailAndPasswordService,
     private val refreshTokenService: RefreshTokenService,
+    private val changePasswordService: ChangePasswordService,
     private val logoutService: LogoutService,
     private val authConverter: AuthConverter,
 ) {
+    @PostMapping("/signup")
+    fun signup(@Valid @RequestBody signupReqDto: SignUpReqDto): ResponseEntity<Void> =
+        signUpService.execute(signupReqDto)
+            .run { ResponseEntity.ok().build() }
 
-    @PostMapping
+    @PostMapping("/gauth")
     fun signInGAuth(@Valid @RequestBody signInGAuthReqDto: SignInGAuthReqDto): ResponseEntity<SignInResDto> =
         authConverter.toDto(signInGAuthReqDto)
             .let { ResponseEntity.ok(signInGAuthService.execute(it)) }
 
-    @PostMapping("/old")
+    @PostMapping
     fun signInEmailAndPassword(@Valid @RequestBody signInEmailAndPasswordReqDto: SignInEmailAndPasswordReqDto): ResponseEntity<SignInResDto> =
         authConverter.toDto(signInEmailAndPasswordReqDto)
             .let { ResponseEntity.ok(signInEmailAndPasswordService.execute(it)) }
@@ -40,6 +46,11 @@ class AuthController (
     @DeleteMapping("/logout")
     fun logout(): ResponseEntity<Void> =
         logoutService.execute()
+            .run { ResponseEntity.ok().build() }
+
+    @PatchMapping("/password")
+    fun changePassword(@Valid @RequestBody newPasswordReqDto: NoAuthNewPasswordReqDto): ResponseEntity<Void> =
+        changePasswordService.execute(newPasswordReqDto)
             .run { ResponseEntity.ok().build() }
 
 }

--- a/src/main/kotlin/com/dotori/v2/domain/auth/presentation/data/req/SignUpReqDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/presentation/data/req/SignUpReqDto.kt
@@ -1,0 +1,41 @@
+package com.dotori.v2.domain.auth.presentation.data.req
+
+import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
+import com.dotori.v2.domain.member.enums.Role
+import java.util.*
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+
+data class SignUpReqDto(
+    @field:NotBlank
+    @field:Size(min = 1, max = 10)
+    val memberName:String,
+
+    @field:NotBlank
+    @field:Size(min = 4, max = 4)
+    val stuNum:String,
+
+    @field:NotBlank
+    @field:Size(min = 4)
+    val password: String,
+
+    @field:NotBlank
+    @field:Pattern(regexp = "^[a-zA-Z0-9]+@gsm.hs.kr$")
+    val email:String,
+
+    val gender: Gender,
+) {
+    fun toEntity(password: String): Member =
+        Member(
+            memberName = memberName,
+            stuNum = stuNum,
+            password = password,
+            email = email,
+            gender = gender,
+            roles = Collections.singletonList(Role.ROLE_MEMBER),
+            ruleViolation = mutableListOf(),
+            profileImage = null
+        )
+}

--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/SignUpService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/SignUpService.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.domain.auth.service
+
+import com.dotori.v2.domain.auth.presentation.data.req.SignUpReqDto
+
+interface SignUpService {
+    fun execute(signUpReqDto: SignUpReqDto)
+}

--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignUpServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignUpServiceImpl.kt
@@ -1,0 +1,38 @@
+package com.dotori.v2.domain.auth.service.impl
+
+import com.dotori.v2.domain.auth.presentation.data.req.SignUpReqDto
+import com.dotori.v2.domain.auth.service.SignUpService
+import com.dotori.v2.domain.email.domain.repository.EmailCertificateRepository
+import com.dotori.v2.domain.email.exception.EmailAuthNotFoundException
+import com.dotori.v2.domain.email.exception.EmailNotBeenException
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.exception.MemberAlreadyException
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class SignUpServiceImpl(
+    private val emailCertificateRepository: EmailCertificateRepository,
+    private val memberRepository: MemberRepository,
+    private val passwordEncoder: PasswordEncoder,
+): SignUpService {
+    override fun execute(signUpReqDto: SignUpReqDto) {
+        val emailCertificate = emailCertificateRepository.findByEmail(signUpReqDto.email)
+            ?: throw EmailAuthNotFoundException()
+
+        if(!emailCertificate.authentication)
+            throw EmailNotBeenException()
+
+        emailCertificateRepository.delete(emailCertificate)
+
+        if(memberRepository.existsByEmail(signUpReqDto.email))
+            throw MemberAlreadyException()
+
+        val encodedPassword = passwordEncoder.encode(signUpReqDto.password)
+        val member = signUpReqDto.toEntity(encodedPassword)
+
+        memberRepository.save(member)
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/auth/util/impl/AuthConverterImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/util/impl/AuthConverterImpl.kt
@@ -8,6 +8,7 @@ import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.auth.presentation.data.dto.SignInGAuthDto
 import com.dotori.v2.domain.auth.presentation.data.req.SignInEmailAndPasswordReqDto
 import com.dotori.v2.domain.auth.presentation.data.req.SignInGAuthReqDto
+import com.dotori.v2.domain.member.enums.Gender
 import gauth.GAuthUserInfo
 import org.springframework.stereotype.Component
 
@@ -29,7 +30,8 @@ class AuthConverterImpl : AuthConverter {
             memberName = gAuthUserInfo.name,
             stuNum = "${gAuthUserInfo.grade}${gAuthUserInfo.classNum}${gAuthUserInfo.num}",
             email = gAuthUserInfo.email,
-            gender = gAuthUserInfo.gender,
+            password = "",
+            gender = convertGender(gAuthUserInfo.gender),
             roles = mutableListOf(role),
             ruleViolation = mutableListOf(),
             profileImage = gAuthUserInfo.profileUrl
@@ -40,7 +42,8 @@ class AuthConverterImpl : AuthConverter {
             memberName = gAuthUserInfo.name,
             stuNum = "${gAuthUserInfo.grade}${gAuthUserInfo.classNum}${gAuthUserInfo.num}",
             email = gAuthUserInfo.email,
-            gender = gAuthUserInfo.gender,
+            password = "",
+            gender = convertGender(gAuthUserInfo.gender),
             roles = mutableListOf(Role.ROLE_ADMIN),
             ruleViolation = mutableListOf(),
             profileImage = gAuthUserInfo.profileUrl
@@ -51,7 +54,8 @@ class AuthConverterImpl : AuthConverter {
             memberName = gAuthUserInfo.name,
             stuNum = "${gAuthUserInfo.grade}${gAuthUserInfo.classNum}${gAuthUserInfo.num}",
             email = gAuthUserInfo.email,
-            gender = gAuthUserInfo.gender,
+            password = "",
+            gender = convertGender(gAuthUserInfo.gender),
             roles = mutableListOf(Role.ROLE_COUNCILLOR),
             ruleViolation = mutableListOf(),
             profileImage = gAuthUserInfo.profileUrl
@@ -62,7 +66,8 @@ class AuthConverterImpl : AuthConverter {
             memberName = gAuthUserInfo.name,
             stuNum = "${gAuthUserInfo.grade}${gAuthUserInfo.classNum}${gAuthUserInfo.num}",
             email = gAuthUserInfo.email,
-            gender = gAuthUserInfo.gender,
+            password = "",
+            gender = convertGender(gAuthUserInfo.gender),
             roles = mutableListOf(Role.ROLE_DEVELOPER),
             ruleViolation = mutableListOf(),
             profileImage = gAuthUserInfo.profileUrl
@@ -80,4 +85,12 @@ class AuthConverterImpl : AuthConverter {
             memberId = memberId,
             token = refreshToken
         )
+
+    private fun convertGender(gender: String): Gender =
+        when (gender) {
+            "MALE" -> Gender.MAN
+            "FEMALE" -> Gender.WOMAN
+            else -> Gender.PENDING
+        }
+
 }

--- a/src/main/kotlin/com/dotori/v2/domain/email/domain/entity/EmailCertificate.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/domain/entity/EmailCertificate.kt
@@ -1,0 +1,35 @@
+package com.dotori.v2.domain.email.domain.entity
+
+import com.dotori.v2.global.entity.BaseTimeEntity
+import java.time.LocalDateTime
+import javax.persistence.*
+
+@Entity
+@Table(name = "email_certificate")
+class EmailCertificate(
+    @Column(name = "certificate_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    val id: Long,
+    @Column(name = "certificate_email", nullable = false)
+    val email: String,
+    @Column(name = "certificate_key", nullable = false)
+    val key: String,
+    @Column(name = "certificate_expired_time", nullable = false)
+    val expiredTime: LocalDateTime,
+    @Column(name = "certificate_authentication", nullable = false)
+    val authentication: Boolean
+) : BaseTimeEntity() {
+
+    constructor(email: String, key: String, expiredTime: LocalDateTime, authentication: Boolean)
+            :this(0, email, key, expiredTime, authentication)
+
+    fun verify(): EmailCertificate =
+        EmailCertificate(
+            id = this.id,
+            email = this.email,
+            key = this.key,
+            expiredTime = this.expiredTime,
+            authentication = true
+        )
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/domain/repository/EmailCertificateRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/domain/repository/EmailCertificateRepository.kt
@@ -1,0 +1,14 @@
+package com.dotori.v2.domain.email.domain.repository
+
+import com.dotori.v2.domain.email.domain.entity.EmailCertificate
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EmailCertificateRepository: JpaRepository<EmailCertificate, Long> {
+    fun deleteByEmail(email: String)
+
+    fun findByKey(key: String): EmailCertificate?
+
+    fun existsByEmail(email: String): Boolean
+
+    fun findByEmail(email: String): EmailCertificate?
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/exception/EmailAuthNotFoundException.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/exception/EmailAuthNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.domain.email.exception
+
+import com.dotori.v2.global.error.ErrorCode
+import com.dotori.v2.global.error.exception.BasicException
+
+class EmailAuthNotFoundException : BasicException(ErrorCode.MAIL_AUTH_NOT_FOUND){
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/exception/EmailNotBeenException.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/exception/EmailNotBeenException.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.domain.email.exception
+
+import com.dotori.v2.global.error.ErrorCode
+import com.dotori.v2.global.error.exception.BasicException
+
+class EmailNotBeenException : BasicException(ErrorCode.MEMBER_EMAIL_HAS_NOT_BEEN_CERTIFICATE) {
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/presentation/EmailController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/presentation/EmailController.kt
@@ -1,0 +1,38 @@
+package com.dotori.v2.domain.email.presentation
+
+import com.dotori.v2.domain.email.presentation.dto.request.EmailCheckReqDto
+import com.dotori.v2.domain.email.presentation.dto.request.EmailReqDto
+import com.dotori.v2.domain.email.service.EmailCheckService
+import com.dotori.v2.domain.email.service.PasswordChangeEmailSendService
+import com.dotori.v2.domain.email.service.SignupEmailSendService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v2/email")
+class EmailController(
+    private val signupEmailSendService: SignupEmailSendService,
+    private val passwordChangeEmailSendService: PasswordChangeEmailSendService,
+    private val emailCheckService: EmailCheckService
+) {
+    @PostMapping("/signup")
+    fun sendEmailSignup(@RequestBody emailReqDto: EmailReqDto): ResponseEntity<Void> {
+        signupEmailSendService.execute(emailReqDto)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/password")
+    fun sendEmailChangePassword(@RequestBody emailReqDto: EmailReqDto): ResponseEntity<Void> {
+        passwordChangeEmailSendService.execute(emailReqDto)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/verify-email")
+    fun verifyEmail(@RequestBody emailCheckReqDto: EmailCheckReqDto): ResponseEntity<Void>{
+        emailCheckService.execute(emailCheckReqDto.key)
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/presentation/dto/request/EmailCheckReqDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/presentation/dto/request/EmailCheckReqDto.kt
@@ -1,0 +1,8 @@
+package com.dotori.v2.domain.email.presentation.dto.request
+
+import javax.validation.constraints.Size
+
+class EmailCheckReqDto(
+    @field:Size(min = 6, max = 6)
+    val key: String
+)

--- a/src/main/kotlin/com/dotori/v2/domain/email/presentation/dto/request/EmailReqDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/presentation/dto/request/EmailReqDto.kt
@@ -1,0 +1,8 @@
+package com.dotori.v2.domain.email.presentation.dto.request
+
+import javax.validation.constraints.Pattern
+
+class EmailReqDto(
+    @field:Pattern(regexp = "^[a-zA-Z0-9]+@gsm.hs.kr$")
+    val email:String,
+)

--- a/src/main/kotlin/com/dotori/v2/domain/email/presentation/dto/response/SenderDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/presentation/dto/response/SenderDto.kt
@@ -1,0 +1,29 @@
+package com.dotori.v2.domain.email.presentation.dto.response
+
+import com.amazonaws.services.simpleemail.model.*
+
+
+class SenderDto(
+    val from: String,
+    val to: String,
+    val subject: String,
+    val content: String
+) {
+    fun toSendRequestDto(): SendEmailRequest {
+        val destination: Destination = Destination()
+            .withToAddresses(to)
+        val message: Message = Message()
+            .withSubject(createContent(subject))
+            .withBody(Body().withHtml(createContent(content)))
+        return SendEmailRequest()
+            .withSource(from)
+            .withDestination(destination)
+            .withMessage(message)
+    }
+
+    private fun createContent(text: String): Content {
+        return Content()
+            .withCharset("UTF-8")
+            .withData(text)
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/service/EmailCheckService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/service/EmailCheckService.kt
@@ -1,0 +1,6 @@
+package com.dotori.v2.domain.email.service
+
+
+interface EmailCheckService {
+    fun execute(key: String)
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/service/EmailSendService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/service/EmailSendService.kt
@@ -1,0 +1,8 @@
+package com.dotori.v2.domain.email.service
+
+import com.dotori.v2.domain.email.presentation.dto.request.EmailReqDto
+
+
+interface EmailSendService {
+    fun execute(emailReqDto: EmailReqDto)
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/service/PasswordChangeEmailSendService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/service/PasswordChangeEmailSendService.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.domain.email.service
+
+import com.dotori.v2.domain.email.presentation.dto.request.EmailReqDto
+
+interface PasswordChangeEmailSendService {
+    fun execute(emailReqDto: EmailReqDto)
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/service/SignupEmailSendService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/service/SignupEmailSendService.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.domain.email.service
+
+import com.dotori.v2.domain.email.presentation.dto.request.EmailReqDto
+
+interface SignupEmailSendService {
+    fun execute(emailReqDto: EmailReqDto)
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/service/impl/EmailCheckServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/service/impl/EmailCheckServiceImpl.kt
@@ -1,0 +1,27 @@
+package com.dotori.v2.domain.email.service.impl
+
+import com.dotori.v2.domain.email.domain.repository.EmailCertificateRepository
+import com.dotori.v2.domain.member.exception.AuthKeyTimeOutException
+import com.dotori.v2.domain.member.exception.AuthKeyNotFoundException
+import com.dotori.v2.domain.email.service.EmailCheckService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class EmailCheckServiceImpl(
+    private val emailCertificateRepository: EmailCertificateRepository,
+) : EmailCheckService {
+    @Transactional(rollbackFor = [Exception::class])
+    override fun execute(key: String) {
+        val findByKey = emailCertificateRepository.findByKey(key)
+            ?: throw AuthKeyNotFoundException()
+
+        if (!findByKey.expiredTime.isAfter(LocalDateTime.now()))
+            throw AuthKeyTimeOutException()
+
+        val emailCertificate = findByKey.verify()
+
+        emailCertificateRepository.save(emailCertificate)
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/service/impl/EmailSendServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/service/impl/EmailSendServiceImpl.kt
@@ -1,0 +1,37 @@
+package com.dotori.v2.domain.email.service.impl
+
+import com.dotori.v2.domain.email.domain.entity.EmailCertificate
+import com.dotori.v2.domain.email.domain.repository.EmailCertificateRepository
+import com.dotori.v2.domain.email.presentation.dto.request.EmailReqDto
+import com.dotori.v2.domain.email.service.EmailSendService
+import com.dotori.v2.global.email.EmailSender
+import com.dotori.v2.global.util.KeyUtil
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class EmailSendServiceImpl(
+    private val emailCertificateRepository: EmailCertificateRepository,
+    private val keyUtil: KeyUtil,
+    private val emailSender: EmailSender,
+) : EmailSendService {
+
+    override fun execute(emailReqDto: EmailReqDto) {
+        val key = keyUtil.keyIssuance()
+        emailSender.send(emailReqDto.email, key)
+
+        if (emailCertificateRepository.existsByEmail(emailReqDto.email))
+            emailCertificateRepository.deleteByEmail(emailReqDto.email)
+
+        val emailCertificate = EmailCertificate(
+            email = emailReqDto.email,
+            key = key,
+            expiredTime = LocalDateTime.now().plusMinutes(5),
+            authentication = false
+        )
+
+        emailCertificateRepository.save(emailCertificate)
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/service/impl/PasswordChangeEmailSendServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/service/impl/PasswordChangeEmailSendServiceImpl.kt
@@ -1,0 +1,21 @@
+package com.dotori.v2.domain.email.service.impl
+
+import com.dotori.v2.domain.email.presentation.dto.request.EmailReqDto
+import com.dotori.v2.domain.email.service.EmailSendService
+import com.dotori.v2.domain.email.service.PasswordChangeEmailSendService
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.exception.MemberNotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class PasswordChangeEmailSendServiceImpl(
+    private val memberRepository: MemberRepository,
+    private val emailSendService: EmailSendService
+) : PasswordChangeEmailSendService {
+    override fun execute(emailReqDto: EmailReqDto) {
+        if (!memberRepository.existsByEmail(emailReqDto.email))
+            throw MemberNotFoundException()
+
+        emailSendService.execute(emailReqDto)
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/email/service/impl/SignupEmailSendServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/email/service/impl/SignupEmailSendServiceImpl.kt
@@ -1,0 +1,23 @@
+package com.dotori.v2.domain.email.service.impl
+
+import com.dotori.v2.domain.email.presentation.dto.request.EmailReqDto
+import com.dotori.v2.domain.email.service.EmailSendService
+import com.dotori.v2.domain.email.service.SignupEmailSendService
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.exception.MemberAlreadyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class SignupEmailSendServiceImpl(
+    private val emailSendService: EmailSendService,
+    private val memberRepository: MemberRepository
+) : SignupEmailSendService {
+    override fun execute(emailReqDto: EmailReqDto) {
+        if (memberRepository.existsByEmail(emailReqDto.email))
+            throw MemberAlreadyException()
+
+        emailSendService.execute(emailReqDto)
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/mainpage/presentation/dto/res/PersonalInfoResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/mainpage/presentation/dto/res/PersonalInfoResDto.kt
@@ -1,12 +1,13 @@
 package com.dotori.v2.domain.mainpage.presentation.dto.res
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 
 data class PersonalInfoResDto(
     val id: Long,
     val stuNum: String,
     val name: String,
-    val gender: String,
+    val gender: Gender,
     val profileImage: String?
 ) {
     constructor(member: Member) : this(id = member.id, stuNum = member.stuNum, name = member.memberName, gender = member.gender, profileImage = member.profileImage)

--- a/src/main/kotlin/com/dotori/v2/domain/massage/presentation/dto/res/MassageMemberResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/massage/presentation/dto/res/MassageMemberResDto.kt
@@ -1,13 +1,14 @@
 package com.dotori.v2.domain.massage.presentation.dto.res
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 
 data class MassageMemberResDto(
     val rank: Long,
     val id: Long,
     val stuNum: String,
     val memberName: String,
-    val gender: String,
+    val gender: Gender,
     val profileUrl: String?
 ) {
     constructor(rank: Long, member: Member) : this(rank = rank, id = member.id, stuNum = member.stuNum, memberName = member.memberName, gender = member.gender, profileUrl = member.profileImage)

--- a/src/main/kotlin/com/dotori/v2/domain/member/domain/entity/Member.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/domain/entity/Member.kt
@@ -1,12 +1,8 @@
 package com.dotori.v2.domain.member.domain.entity
 
-import com.dotori.v2.domain.member.enums.MassageStatus
-import com.dotori.v2.domain.member.enums.MusicStatus
-import com.dotori.v2.domain.member.enums.Role
-import com.dotori.v2.domain.member.enums.SelfStudyStatus
+import com.dotori.v2.domain.member.enums.*
 import com.dotori.v2.domain.rule.domain.entity.RuleViolation
 import com.dotori.v2.global.entity.BaseTimeEntity
-import org.hibernate.annotations.ColumnDefault
 import java.time.LocalDateTime
 import javax.persistence.*
 
@@ -22,17 +18,17 @@ class Member(
     @Column(name = "member_name", nullable = false)
     val memberName: String,
 
-    @Column(name = "member_password", nullable = true)
-    val password: String = "string1!",
-
     @Column(name = "member_stuNum", nullable = false)
     val stuNum: String,
 
     @Column(name = "member_email", nullable = false, unique = true)
     val email: String,
 
+    password: String,
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "member_gender")
-    val gender: String,
+    val gender: Gender,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "Role")
@@ -55,6 +51,10 @@ class Member(
     var selfStudyCheck = false
         private set
 
+    @Column(name = "member_password", nullable = false)
+    var password: String = password
+        private set
+
     @Column(name = "self_study_expired_date")
     var selfStudyExpiredDate: LocalDateTime? = null
         private set
@@ -73,6 +73,10 @@ class Member(
     @Column(name = "member_massage", nullable = false)
     var massageStatus: MassageStatus = MassageStatus.CAN
         private set
+
+    fun updatePassword(newPassword: String) {
+        this.password = newPassword
+    }
 
     fun updateSelfStudyStatus(selfStudyStatus: SelfStudyStatus) {
         this.selfStudyStatus = selfStudyStatus

--- a/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepositoryImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/domain/repository/CustomMemberRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.dotori.v2.domain.member.domain.repository
 
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.domain.entity.QMember.member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.selfstudy.presentation.dto.req.SelfStudySearchReqDto
@@ -62,7 +63,7 @@ class CustomMemberRepositoryImpl(
         if(hasText(classNum)) member.stuNum.substring(1,2).eq(classNum) else null
 
     private fun genderEq(gender: String?): BooleanExpression? =
-        if(hasText(gender)) member.gender.eq(gender) else null
+        if(hasText(gender)) member.gender.eq(Gender.valueOf(gender!!)) else null
 
     private fun roleEq(role: String?): BooleanExpression? =
         if(hasText(role)) member.roles.any().eq(Role.valueOf(role!!)) else null

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/MemberController.kt
@@ -1,19 +1,30 @@
 package com.dotori.v2.domain.member.presentation
 
-import com.dotori.v2.domain.member.service.DeleteProfileImageService
-import com.dotori.v2.domain.member.service.UpdateProfileImageService
-import com.dotori.v2.domain.member.service.UploadProfileImageService
+import com.dotori.v2.domain.member.presentation.data.req.NewPasswordReqDto
+import com.dotori.v2.domain.member.service.*
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/v2/members")
 class MemberController(
+    private val withdrawalService: WithdrawalService,
+    private val changeAuthPasswordService: ChangeAuthPasswordService,
     private val uploadProfileImageService: UploadProfileImageService,
     private val updateProfileImageService: UpdateProfileImageService,
     private val deleteProfileImageService: DeleteProfileImageService
 ) {
+    @DeleteMapping("/withdrawal")
+    fun withdrawal(): ResponseEntity<Void> =
+        withdrawalService.execute()
+            .run { ResponseEntity.ok().build() }
+
+    @PatchMapping("/password")
+    fun changePassword(@Valid @RequestBody newPasswordReqDto: NewPasswordReqDto): ResponseEntity<Void> =
+        changeAuthPasswordService.execute(newPasswordReqDto)
+            .run { ResponseEntity.ok().build() }
 
     @PostMapping("/profileImage")
     fun uploadProfileImage(@RequestParam(value = "image") multipartFiles: MultipartFile?): ResponseEntity<Void> =

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/dto/MemberDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/dto/MemberDto.kt
@@ -1,11 +1,12 @@
 package com.dotori.v2.domain.member.presentation.data.dto
 
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.rule.enums.Rule
 
 data class MemberDto(
     val id: Long,
     val memberName: String,
     val stuNum: String,
-    val gender: String,
+    val gender: Gender,
     val rule: List<Rule>
 )

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NewPasswordReqDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NewPasswordReqDto.kt
@@ -1,0 +1,13 @@
+package com.dotori.v2.domain.member.presentation.data.req
+
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
+
+data class NewPasswordReqDto(
+    @field:NotBlank
+    @field:Size(min = 4)
+    val currentPassword: String,
+    @field:NotBlank
+    @field:Size(min = 4)
+    val newPassword: String
+)

--- a/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NoAuthNewPasswordReqDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/presentation/data/req/NoAuthNewPasswordReqDto.kt
@@ -1,0 +1,14 @@
+package com.dotori.v2.domain.member.presentation.data.req
+
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+
+data class NoAuthNewPasswordReqDto(
+    @field:NotBlank
+    @field:Pattern(regexp = "^[a-zA-Z0-9]+@gsm.hs.kr$")
+    val email: String,
+    @field:NotBlank
+    @field:Size(min = 4)
+    val newPassword: String,
+)

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/ChangeAuthPasswordService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/ChangeAuthPasswordService.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.domain.member.service
+
+import com.dotori.v2.domain.member.presentation.data.req.NewPasswordReqDto
+
+interface ChangeAuthPasswordService {
+    fun execute(newPasswordReqDto: NewPasswordReqDto)
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/ChangePasswordService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/ChangePasswordService.kt
@@ -1,0 +1,7 @@
+package com.dotori.v2.domain.member.service
+
+import com.dotori.v2.domain.member.presentation.data.req.NoAuthNewPasswordReqDto
+
+interface ChangePasswordService {
+    fun execute(newPasswordReqDto: NoAuthNewPasswordReqDto)
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/WithdrawalService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/WithdrawalService.kt
@@ -1,0 +1,5 @@
+package com.dotori.v2.domain.member.service
+
+interface WithdrawalService {
+    fun execute()
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/ChangeAuthPasswordServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/ChangeAuthPasswordServiceImpl.kt
@@ -1,0 +1,25 @@
+package com.dotori.v2.domain.member.service.impl
+
+import com.dotori.v2.domain.member.exception.PasswordMismatchException
+import com.dotori.v2.domain.member.presentation.data.req.NewPasswordReqDto
+import com.dotori.v2.domain.member.service.ChangeAuthPasswordService
+import com.dotori.v2.global.util.UserUtil
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class ChangeAuthPasswordServiceImpl(
+    private val userUtil: UserUtil,
+    private val passwordEncoder: PasswordEncoder
+): ChangeAuthPasswordService {
+    override fun execute(newPasswordReqDto: NewPasswordReqDto) {
+        val member = userUtil.fetchCurrentUser()
+
+        if (!passwordEncoder.matches(newPasswordReqDto.currentPassword, member.password))
+            throw PasswordMismatchException()
+
+        member.updatePassword(passwordEncoder.encode(newPasswordReqDto.newPassword))
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/ChangePasswordServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/ChangePasswordServiceImpl.kt
@@ -1,0 +1,33 @@
+package com.dotori.v2.domain.member.service.impl
+
+import com.dotori.v2.domain.email.domain.repository.EmailCertificateRepository
+import com.dotori.v2.domain.email.exception.EmailAuthNotFoundException
+import com.dotori.v2.domain.email.exception.EmailNotBeenException
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.exception.MemberNotFoundException
+import com.dotori.v2.domain.member.presentation.data.req.NoAuthNewPasswordReqDto
+import com.dotori.v2.domain.member.service.ChangePasswordService
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class ChangePasswordServiceImpl(
+    private val memberRepository: MemberRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val emailCertificateRepository: EmailCertificateRepository,
+) : ChangePasswordService {
+    override fun execute(newPasswordReqDto: NoAuthNewPasswordReqDto) {
+        val emailCertificate = emailCertificateRepository.findByEmail(newPasswordReqDto.email)
+            ?: throw EmailAuthNotFoundException()
+
+        if (!emailCertificate.authentication)
+            throw EmailNotBeenException()
+
+        val member = (memberRepository.findByEmail(newPasswordReqDto.email)
+            ?: throw MemberNotFoundException())
+
+        member.updatePassword(passwordEncoder.encode(newPasswordReqDto.newPassword))
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/WithdrawalServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/WithdrawalServiceImpl.kt
@@ -1,0 +1,22 @@
+package com.dotori.v2.domain.member.service.impl
+
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.service.WithdrawalService
+import com.dotori.v2.global.thirdparty.aws.s3.S3Service
+import com.dotori.v2.global.util.UserUtil
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+class WithdrawalServiceImpl(
+    private val memberRepository: MemberRepository,
+    private val s3Service: S3Service,
+    private val userUtil: UserUtil,
+) : WithdrawalService {
+    override fun execute() {
+        val currentUser = userUtil.fetchCurrentUser()
+        currentUser.profileImage?.let { s3Service.deleteFile(it) }
+        memberRepository.delete(currentUser)
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/rule/service/impl/FindStudentServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/rule/service/impl/FindStudentServiceImpl.kt
@@ -32,7 +32,7 @@ class FindStudentServiceImpl(
                 }.filter {
                     if (classNum != null) it.stuNum.substring(1, 2) == classNum else true
                 }.filter {
-                    if (gender != null) it.gender == gender else true
+                    if (gender != null) it.gender.name == gender else true
                 }.toList().map { it.toDto() }
             }
         )

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/presentation/dto/res/SelfStudyMemberResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/presentation/dto/res/SelfStudyMemberResDto.kt
@@ -1,13 +1,14 @@
 package com.dotori.v2.domain.selfstudy.presentation.dto.res
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 
 data class SelfStudyMemberResDto(
     val rank: Long,
     val id: Long,
     val stuNum: String,
     val memberName: String,
-    val gender: String,
+    val gender: Gender,
     val selfStudyCheck: Boolean,
     val profileUrl: String?
 ) {

--- a/src/main/kotlin/com/dotori/v2/domain/student/presentation/data/req/ModifyStudentInfoRequest.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/student/presentation/data/req/ModifyStudentInfoRequest.kt
@@ -1,11 +1,12 @@
 package com.dotori.v2.domain.student.presentation.data.req
 
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 
 data class ModifyStudentInfoRequest(
     val memberId: Long,
     val memberName: String,
     val stuNum: String,
-    val gender: String,
+    val gender: Gender,
     val role: Role
 )

--- a/src/main/kotlin/com/dotori/v2/domain/student/presentation/data/res/FindAllStudentResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/student/presentation/data/res/FindAllStudentResDto.kt
@@ -1,11 +1,12 @@
 package com.dotori.v2.domain.student.presentation.data.res
 
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 
 data class FindAllStudentResDto(
     val id: Long,
-    val gender: String,
+    val gender: Gender,
     val memberName: String,
     val stuNum: String,
     val role: Role,

--- a/src/main/kotlin/com/dotori/v2/domain/student/presentation/data/res/SearchStudentListResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/student/presentation/data/res/SearchStudentListResDto.kt
@@ -1,5 +1,6 @@
 package com.dotori.v2.domain.student.presentation.data.res
 
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 
@@ -8,7 +9,7 @@ data class SearchStudentListResDto(
     val email: String?,
     val memberName: String,
     val stuNum: String,
-    val gender: String,
+    val gender: Gender,
     val role: Role,
     val selfStudyStatus: SelfStudyStatus
 )

--- a/src/main/kotlin/com/dotori/v2/domain/student/service/impl/ModifyStudentInfoServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/student/service/impl/ModifyStudentInfoServiceImpl.kt
@@ -26,6 +26,7 @@ class ModifyStudentInfoServiceImpl(
             memberName = modifyStudentInfoRequest.memberName,
             stuNum = modifyStudentInfoRequest.stuNum,
             email = member.email,
+            password = member.password,
             gender = modifyStudentInfoRequest.gender,
             roles = Collections.singletonList(modifyStudentInfoRequest.role),
             ruleViolation = member.ruleViolation,

--- a/src/main/kotlin/com/dotori/v2/global/config/dev/DevMemberConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/dev/DevMemberConfig.kt
@@ -2,6 +2,7 @@ package com.dotori.v2.global.config.dev
 
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import org.springframework.context.annotation.Profile
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -22,7 +23,7 @@ class DevMemberConfig(
             stuNum = "0000",
             email = "s00000@gsm.hs.kr",
             password = password,
-            gender = "PENDING",
+            gender = Gender.PENDING,
             roles = mutableListOf(Role.ROLE_ADMIN),
             ruleViolation = mutableListOf(),
             profileImage = null
@@ -34,7 +35,7 @@ class DevMemberConfig(
             stuNum = "0001",
             email = "s00001@gsm.hs.kr",
             password = password,
-            gender = "PENDING",
+            gender = Gender.PENDING,
             roles = mutableListOf(Role.ROLE_DEVELOPER),
             ruleViolation = mutableListOf(),
             profileImage = null
@@ -46,7 +47,7 @@ class DevMemberConfig(
             stuNum = "0002",
             email = "s00002@gsm.hs.kr",
             password = password,
-            gender = "PENDING",
+            gender = Gender.PENDING,
             roles = mutableListOf(Role.ROLE_COUNCILLOR),
             ruleViolation = mutableListOf(),
             profileImage = null
@@ -58,7 +59,7 @@ class DevMemberConfig(
             stuNum = "3101",
             email = "s00003@gsm.hs.kr",
             password = password,
-            gender = "MALE",
+            gender = Gender.PENDING,
             roles = mutableListOf(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null
@@ -70,7 +71,7 @@ class DevMemberConfig(
             stuNum = "3201",
             email = "s00004@gsm.hs.kr",
             password = password,
-            gender = "FEMALE",
+            gender = Gender.PENDING,
             roles = mutableListOf(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/main/kotlin/com/dotori/v2/global/email/EmailSender.kt
+++ b/src/main/kotlin/com/dotori/v2/global/email/EmailSender.kt
@@ -1,0 +1,45 @@
+package com.dotori.v2.global.email
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder
+import com.amazonaws.services.simpleemail.model.SendEmailResult
+import com.dotori.v2.domain.email.presentation.dto.response.SenderDto
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class EmailSender(
+    private val amazonSimpleEmailService: AmazonSimpleEmailService
+) {
+
+    @Value("\${aws.ses.verified.email}")
+    private val from = ""
+    private val log = LoggerFactory.getLogger(this::class.simpleName)
+
+    fun send(receivers: String?, key: String) {
+        val subject = "🎈[DOTORI] 인증 키"
+        var message = "<p style=\"color:blueviolet\">안녕하세요 Dotori 계정에 사용할 일회용 코드에 대한 요청을 받았습니다.</p>"
+        message += "<p>일회용 코드: $key</p>"
+        message += "<p>이 코드를 요청하지 않은 경우 이 메일을 무시하셔도 됩니다. 다른 사람이 실수로 귀하의 이메일 주소를 입력했을 수 있습니다.</p>"
+        message += "<p>감사합니다 Dotori 계정 팀</p>"
+        if (receivers == null) {
+            log.error("메일을 전송할 대상이 없습니다: [{}]", subject)
+            return
+        }
+        val senderDto: SenderDto = SenderDto(
+            from = from,
+            to = receivers,
+            subject = subject,
+            content = message,
+        )
+        val sendEmailResult: SendEmailResult = amazonSimpleEmailService.sendEmail(senderDto.toSendRequestDto())
+        if (sendEmailResult.sdkHttpMetadata.httpStatusCode === 200) {
+            log.info("[AWS SES] 메일전송완료 => $senderDto")
+        } else {
+            log.error("[AWS SES] 메일전송 중 에러가 발생했습니다: {}", sendEmailResult.sdkResponseMetadata.toString())
+            log.error("발송실패 대상자: " + senderDto.to + " / subject: " + senderDto.subject)
+        }
+    }
+
+}

--- a/src/main/kotlin/com/dotori/v2/global/util/KeyUtil.kt
+++ b/src/main/kotlin/com/dotori/v2/global/util/KeyUtil.kt
@@ -1,0 +1,18 @@
+package com.dotori.v2.global.util
+
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class KeyUtil {
+    fun keyIssuance(): String {
+        val random = Random()
+        val buffer = StringBuffer()
+        var num = 0
+        while (buffer.length < 6) {
+            num = random.nextInt(10)
+            buffer.append(num)
+        }
+        return buffer.toString()
+    }
+}

--- a/src/test/kotlin/com/dotori/v2/domain/board/controller/CreateBoardControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/board/controller/CreateBoardControllerTest.kt
@@ -7,6 +7,7 @@ import com.dotori.v2.domain.board.presentation.data.req.CreateBoardReqDto
 import com.dotori.v2.domain.board.presentation.developer.DeveloperBoardController
 import com.dotori.v2.domain.board.service.*
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -63,7 +64,8 @@ class CreateBoardControllerTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/board/service/DeleteMultipleBoardServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/board/service/DeleteMultipleBoardServiceTest.kt
@@ -7,6 +7,7 @@ import com.dotori.v2.domain.board.domain.repository.BoardRepository
 import com.dotori.v2.domain.board.presentation.data.req.DeleteMultipleBoardReqDto
 import com.dotori.v2.domain.board.service.impl.DeleteMultipleBoardServiceImpl
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import io.kotest.core.spec.style.BehaviorSpec
@@ -27,7 +28,8 @@ class DeleteMultipleBoardServiceTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/mainpage/controller/GetPersonalInfoControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/mainpage/controller/GetPersonalInfoControllerTest.kt
@@ -3,6 +3,7 @@ package com.dotori.v2.domain.mainpage.controller
 import com.dotori.v2.domain.mainpage.presentation.GetPersonalInfoController
 import com.dotori.v2.domain.mainpage.presentation.dto.res.PersonalInfoResDto
 import com.dotori.v2.domain.mainpage.service.GetPersonalInfoService
+import com.dotori.v2.domain.member.enums.Gender
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -16,7 +17,7 @@ class GetPersonalInfoControllerTest : BehaviorSpec({
 
     given("요청이 들어오면") {
         `when`("is received") {
-            val target = PersonalInfoResDto(1, "test", "test", "MALE", null)
+            val target = PersonalInfoResDto(1, "test", "test", Gender.MAN, null)
             every { getPersonalInfoService.execute() } returns target
             val response = controller.getPersonalInfo()
             then("서비스가 한번은 실행되어야 함") {

--- a/src/test/kotlin/com/dotori/v2/domain/mainpage/service/BoardAlarmServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/mainpage/service/BoardAlarmServiceTest.kt
@@ -6,6 +6,7 @@ import com.dotori.v2.domain.board.presentation.data.dto.BoardDto
 import com.dotori.v2.domain.mainpage.presentation.dto.res.BoardAlarmResDto
 import com.dotori.v2.domain.mainpage.service.impl.BoardAlarmServiceImpl
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -21,7 +22,8 @@ class BoardAlarmServiceTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/LogoutControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/LogoutControllerTest.kt
@@ -1,14 +1,10 @@
 package com.dotori.v2.domain.member.controller
 
 import com.dotori.v2.domain.auth.presentation.AuthController
-import com.dotori.v2.domain.member.presentation.MemberController
-import com.dotori.v2.domain.member.service.DeleteProfileImageService
-import com.dotori.v2.domain.auth.service.LogoutService
-import com.dotori.v2.domain.auth.service.RefreshTokenService
-import com.dotori.v2.domain.auth.service.SignInEmailAndPasswordService
-import com.dotori.v2.domain.auth.service.SignInGAuthService
+import com.dotori.v2.domain.auth.service.*
 import com.dotori.v2.domain.auth.util.AuthConverter
 import com.dotori.v2.domain.auth.util.impl.AuthConverterImpl
+import com.dotori.v2.domain.member.service.ChangePasswordService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -27,13 +23,17 @@ class LogoutControllerTest : BehaviorSpec({
     val signInGAuthService = mockk<SignInGAuthService>()
     val signInEmailAndPasswordService = mockk<SignInEmailAndPasswordService>()
     val logoutService = mockk<LogoutService>()
+    val signUpService = mockk<SignUpService>()
+    val changePasswordService = mockk<ChangePasswordService>()
 
     val authController = AuthController(
         authConverter = authConverter(),
         signInGAuthService = signInGAuthService,
         signInEmailAndPasswordService = signInEmailAndPasswordService,
         refreshTokenService = refreshTokenService,
-        logoutService = logoutService
+        logoutService = logoutService,
+        signUpService = signUpService,
+        changePasswordService = changePasswordService
     )
 
     given("요청이 들어오면") {

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/RefreshTokenControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/RefreshTokenControllerTest.kt
@@ -4,10 +4,8 @@ import com.dotori.v2.domain.auth.presentation.AuthController
 import com.dotori.v2.domain.auth.util.AuthConverter
 import com.dotori.v2.domain.auth.util.impl.AuthConverterImpl
 import com.dotori.v2.domain.auth.presentation.data.res.RefreshResDto
-import com.dotori.v2.domain.auth.service.LogoutService
-import com.dotori.v2.domain.auth.service.RefreshTokenService
-import com.dotori.v2.domain.auth.service.SignInEmailAndPasswordService
-import com.dotori.v2.domain.auth.service.SignInGAuthService
+import com.dotori.v2.domain.auth.service.*
+import com.dotori.v2.domain.member.service.ChangePasswordService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -27,12 +25,17 @@ class RefreshTokenControllerTest : BehaviorSpec({
     val signInGAuthService = mockk<SignInGAuthService>()
     val signInEmailAndPasswordService = mockk<SignInEmailAndPasswordService>()
     val logoutService = mockk<LogoutService>()
+    val signUpService = mockk<SignUpService>()
+    val changePasswordService = mockk<ChangePasswordService>()
+
     val authController = AuthController(
         authConverter = authConverter(),
         signInGAuthService = signInGAuthService,
         signInEmailAndPasswordService = signInEmailAndPasswordService,
         refreshTokenService = refreshTokenService,
-        logoutService = logoutService
+        logoutService = logoutService,
+        signUpService = signUpService,
+        changePasswordService = changePasswordService
     )
 
 

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/SignInControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/SignInControllerTest.kt
@@ -6,10 +6,8 @@ import com.dotori.v2.domain.auth.util.impl.AuthConverterImpl
 import com.dotori.v2.domain.auth.presentation.data.dto.SignInGAuthDto
 import com.dotori.v2.domain.auth.presentation.data.req.SignInGAuthReqDto
 import com.dotori.v2.domain.auth.presentation.data.res.SignInResDto
-import com.dotori.v2.domain.auth.service.LogoutService
-import com.dotori.v2.domain.auth.service.RefreshTokenService
-import com.dotori.v2.domain.auth.service.SignInEmailAndPasswordService
-import com.dotori.v2.domain.auth.service.SignInGAuthService
+import com.dotori.v2.domain.auth.service.*
+import com.dotori.v2.domain.member.service.ChangePasswordService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -28,12 +26,17 @@ class SignInControllerTest : BehaviorSpec({
     val signInGAuthService = mockk<SignInGAuthService>()
     val signInEmailAndPasswordService = mockk<SignInEmailAndPasswordService>()
     val logoutService = mockk<LogoutService>()
+    val signUpService = mockk<SignUpService>()
+    val changePasswordService = mockk<ChangePasswordService>()
+
     val authController = AuthController(
         authConverter = authConverter(),
         signInGAuthService = signInGAuthService,
         signInEmailAndPasswordService = signInEmailAndPasswordService,
         refreshTokenService = refreshTokenService,
-        logoutService = logoutService
+        logoutService = logoutService,
+        signUpService = signUpService,
+        changePasswordService = changePasswordService
     )
     given("요청이 들어오면") {
         val dto = SignInGAuthDto(

--- a/src/test/kotlin/com/dotori/v2/domain/member/service/LogoutServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/service/LogoutServiceTest.kt
@@ -3,6 +3,7 @@ package com.dotori.v2.domain.member.service
 import com.dotori.v2.domain.auth.domain.repository.RefreshTokenRepository
 import com.dotori.v2.domain.auth.service.impl.LogoutServiceImpl
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.global.util.UserUtil
 import com.dotori.v2.testUtil.TestUtils
@@ -21,7 +22,8 @@ class LogoutServiceTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/member/service/SignInServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/service/SignInServiceTest.kt
@@ -9,6 +9,7 @@ import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.auth.presentation.data.dto.SignInGAuthDto
 import com.dotori.v2.domain.auth.service.impl.SignInGAuthServiceImpl
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.global.config.gauth.properties.GAuthProperties
 import com.dotori.v2.global.security.jwt.TokenProvider
 import gauth.GAuth
@@ -69,7 +70,7 @@ class SignInServiceTest : BehaviorSpec({
         val refreshToken = "thisIsRefreshToken"
 
         val role = Role.ROLE_MEMBER
-        val member = Member(1, "최민욱", "string1!","2216", "s22034@gsm.hs.kr", "MALE", mutableListOf(role), mutableListOf(), null)
+        val member = Member(1, "최민욱", "string1!","2216", "s22034@gsm.hs.kr", Gender.MAN, mutableListOf(role), mutableListOf(), null)
 
         val userMap: Map<String, Any> = mapOf(
             "email" to member.email,

--- a/src/test/kotlin/com/dotori/v2/domain/member/util/MemberUtil.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/util/MemberUtil.kt
@@ -1,6 +1,7 @@
 package com.dotori.v2.domain.member.util
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.rule.domain.entity.RuleViolation
 
@@ -12,7 +13,7 @@ class MemberUtil {
             stuNum: String = "0000",
             password: String = "string1!",
             email: String = "s00000@gsm.hs.kr",
-            gender: String = "MALE",
+            gender: Gender = Gender.MAN,
             roles: MutableList<Role> = mutableListOf(Role.ROLE_MEMBER),
             ruleViolation: MutableList<RuleViolation> = mutableListOf(),
             profileImage: String? = null

--- a/src/test/kotlin/com/dotori/v2/domain/music/service/ApplyMusicServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/music/service/ApplyMusicServiceTest.kt
@@ -1,6 +1,7 @@
 package com.dotori.v2.domain.music.service
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.MusicStatus
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.music.domain.entity.Music
@@ -33,7 +34,8 @@ class ApplyMusicServiceTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2402",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceSynchronicityTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceSynchronicityTest.kt
@@ -40,7 +40,8 @@ class ApplySelfStudyServiceSynchronicityTest  : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = Gender.MAN.name,
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceTest.kt
@@ -1,6 +1,7 @@
 package com.dotori.v2.domain.selfstudy.service
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.selfstudy.domain.entity.SelfStudyCount
@@ -41,7 +42,8 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/BanSelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/BanSelfStudyServiceTest.kt
@@ -2,6 +2,7 @@ package com.dotori.v2.domain.selfstudy.service
 
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
@@ -22,7 +23,8 @@ class BanSelfStudyServiceTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = mutableListOf(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/CancelSelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/CancelSelfStudyServiceTest.kt
@@ -1,6 +1,7 @@
 package com.dotori.v2.domain.selfstudy.service
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.selfstudy.domain.entity.SelfStudyCount
@@ -39,7 +40,8 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/GetSelfStudyInfoServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/GetSelfStudyInfoServiceTest.kt
@@ -1,6 +1,7 @@
 package com.dotori.v2.domain.selfstudy.service
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.selfstudy.domain.entity.SelfStudyCount
 import com.dotori.v2.domain.selfstudy.domain.repository.SelfStudyCountRepository
@@ -25,7 +26,8 @@ class GetSelfStudyInfoServiceTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/GetSelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/GetSelfStudyServiceTest.kt
@@ -1,6 +1,7 @@
 package com.dotori.v2.domain.selfstudy.service
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.selfstudy.domain.entity.SelfStudy
 import com.dotori.v2.domain.selfstudy.domain.repository.SelfStudyRepository
@@ -23,7 +24,8 @@ class GetSelfStudyServiceTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/UpdateSelfStudyCheckServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/UpdateSelfStudyCheckServiceTest.kt
@@ -2,6 +2,7 @@ package com.dotori.v2.domain.selfstudy.service
 
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.selfstudy.domain.entity.SelfStudy
@@ -26,7 +27,8 @@ class UpdateSelfStudyCheckServiceTest : BehaviorSpec({
             memberName = "test",
             stuNum = "2116",
             email = "test@gsm.hs.kr",
-            gender = "MALE",
+            password = "password1234",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             ruleViolation = mutableListOf(),
             profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/UpdateSelfStudyStatusServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/UpdateSelfStudyStatusServiceTest.kt
@@ -2,6 +2,7 @@ package com.dotori.v2.domain.selfstudy.service
 
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.selfstudy.domain.entity.SelfStudyCount
@@ -66,7 +67,8 @@ private fun createLiftedBanMember() : Member {
         memberName = "test",
         stuNum = "2116",
         email = "test@gsm.hs.kr",
-        gender = "MALE",
+        password = "password1234",
+        gender = Gender.MAN,
         roles = Collections.singletonList(Role.ROLE_MEMBER),
         ruleViolation = mutableListOf(),
         profileImage = null
@@ -81,7 +83,8 @@ private fun createBanedMember() : Member {
         memberName = "test",
         stuNum = "2116",
         email = "test@gsm.hs.kr",
-        gender = "MALE",
+        password = "password1234",
+        gender = Gender.MAN,
         roles = Collections.singletonList(Role.ROLE_MEMBER),
         ruleViolation = mutableListOf(),
         profileImage = null
@@ -96,7 +99,8 @@ private fun createAppliedMember() : Member {
         memberName = "test",
         stuNum = "2116",
         email = "test@gsm.hs.kr",
-        gender = "MALE",
+        password = "password1234",
+        gender = Gender.MAN,
         roles = Collections.singletonList(Role.ROLE_MEMBER),
         ruleViolation = mutableListOf(),
         profileImage = null

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/util/SelfStudyCheckUtilTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/util/SelfStudyCheckUtilTest.kt
@@ -1,6 +1,7 @@
 package com.dotori.v2.domain.selfstudy.util
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.selfstudy.exception.AlreadyApplySelfStudyException
@@ -17,8 +18,9 @@ class SelfStudyCheckUtilTest : BehaviorSpec({
             memberName = "test",
             stuNum = "1111",
             email = "test@gsm.hs.kr",
+            password = "password1234",
             ruleViolation = mutableListOf(),
-            gender = "MALE",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             profileImage = null
         )
@@ -42,8 +44,9 @@ class SelfStudyCheckUtilTest : BehaviorSpec({
             memberName = "test",
             stuNum = "1111",
             email = "test@gsm.hs.kr",
+            password = "password1234",
             ruleViolation = mutableListOf(),
-            gender = "MALE",
+            gender = Gender.MAN,
             roles = Collections.singletonList(Role.ROLE_MEMBER),
             profileImage = null
         )

--- a/src/test/kotlin/com/dotori/v2/testUtil/MemberDataUtil.kt
+++ b/src/test/kotlin/com/dotori/v2/testUtil/MemberDataUtil.kt
@@ -1,6 +1,7 @@
 package com.dotori.v2.testUtil
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.enums.Gender
 import com.dotori.v2.domain.member.enums.Role
 
 object MemberDataUtil {
@@ -13,7 +14,8 @@ object MemberDataUtil {
         memberName = memberName(),
         stuNum = memberNum(),
         email = email(),
-        gender = "MALE",
+        password = "password1234",
+        gender = Gender.MAN,
         roles = mutableListOf(Role.ROLE_MEMBER),
         ruleViolation = mutableListOf(),
         profileImage = profileImage(),


### PR DESCRIPTION
💡 개요
- 기존 회원가입, 이메일등 유저 기능을 복구했습니다.

📃 작업내용
- GAuth 이전의 회원가입, 이메일등 유저 기능을 복구했습니다.
- User 엔티티에 삭제 되었던 password 필드를 복구했습니다.
- GAuth로 로그인 방식을 변경하면서 수정되었던 gender 필드를 String 에서 enum class 로 수정했습니다.

🔀 변경사항

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타