### PR TITLE
277 token response 필드 추가

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/auth/presentation/data/res/RefreshResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/presentation/data/res/RefreshResDto.kt
@@ -11,5 +11,7 @@ data class RefreshResDto (
     val accessExp: ZonedDateTime,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val refreshExp: ZonedDateTime,
-    val roles: MutableList<Role>
+    val roles: MutableList<Role>,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    val expiresAt: ZonedDateTime
 )

--- a/src/main/kotlin/com/dotori/v2/domain/auth/presentation/data/res/RefreshResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/presentation/data/res/RefreshResDto.kt
@@ -1,5 +1,6 @@
 package com.dotori.v2.domain.auth.presentation.data.res
 
+import com.dotori.v2.domain.member.enums.Role
 import com.fasterxml.jackson.annotation.JsonFormat
 import java.time.ZonedDateTime
 
@@ -9,5 +10,6 @@ data class RefreshResDto (
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val accessExp: ZonedDateTime,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    val refreshExp: ZonedDateTime
+    val refreshExp: ZonedDateTime,
+    val roles: MutableList<Role>
 )

--- a/src/main/kotlin/com/dotori/v2/domain/auth/presentation/data/res/SignInResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/presentation/data/res/SignInResDto.kt
@@ -11,5 +11,7 @@ data class SignInResDto(
     val accessExp: ZonedDateTime,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val refreshExp: ZonedDateTime,
-    val roles: MutableList<Role>
+    val roles: MutableList<Role>,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    val expiresAt: ZonedDateTime
 )

--- a/src/main/kotlin/com/dotori/v2/domain/auth/presentation/data/res/SignInResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/presentation/data/res/SignInResDto.kt
@@ -1,5 +1,6 @@
 package com.dotori.v2.domain.auth.presentation.data.res
 
+import com.dotori.v2.domain.member.enums.Role
 import com.fasterxml.jackson.annotation.JsonFormat
 import java.time.ZonedDateTime
 
@@ -9,5 +10,6 @@ data class SignInResDto(
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val accessExp: ZonedDateTime,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    val refreshExp: ZonedDateTime
+    val refreshExp: ZonedDateTime,
+    val roles: MutableList<Role>
 )

--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/RefreshTokenServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/RefreshTokenServiceImpl.kt
@@ -54,7 +54,8 @@ class RefreshTokenServiceImpl(
             refreshToken = newRefreshToken,
             accessExp = accessExp,
             refreshExp = refreshExp,
-            roles = member.roles
+            roles = member.roles,
+            expiresAt = accessExp
         )
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/RefreshTokenServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/RefreshTokenServiceImpl.kt
@@ -5,6 +5,8 @@ import com.dotori.v2.domain.auth.util.AuthConverter
 import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.auth.presentation.data.res.RefreshResDto
 import com.dotori.v2.domain.auth.service.RefreshTokenService
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.global.security.exception.TokenExpiredException
 import com.dotori.v2.global.security.exception.TokenInvalidException
 import com.dotori.v2.global.security.jwt.TokenProvider
@@ -16,6 +18,7 @@ import java.time.ZonedDateTime
 @Transactional(rollbackFor = [Exception::class])
 class RefreshTokenServiceImpl(
     private val refreshTokenRepository: RefreshTokenRepository,
+    private val memberRepository: MemberRepository,
     private val authConverter: AuthConverter,
     private val tokenProvider: TokenProvider,
 ) : RefreshTokenService {
@@ -25,6 +28,9 @@ class RefreshTokenServiceImpl(
             ?: throw TokenInvalidException()
 
         val email: String = tokenProvider.exactEmailFromRefreshToken(refresh)
+
+        val member = (memberRepository.findByEmail(email)
+            ?: throw MemberNotFoundException())
 
         val role: Role = tokenProvider.exactRoleFromRefreshToken(refresh)
 
@@ -47,7 +53,8 @@ class RefreshTokenServiceImpl(
             accessToken = newAccessToken,
             refreshToken = newRefreshToken,
             accessExp = accessExp,
-            refreshExp = refreshExp
+            refreshExp = refreshExp,
+            roles = member.roles
         )
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignInEmailAndPasswordServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignInEmailAndPasswordServiceImpl.kt
@@ -6,6 +6,7 @@ import com.dotori.v2.domain.auth.presentation.data.dto.SignInEmailAndPasswordDto
 import com.dotori.v2.domain.auth.presentation.data.res.SignInResDto
 import com.dotori.v2.domain.auth.service.SignInEmailAndPasswordService
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.member.exception.PasswordMismatchException
 import com.dotori.v2.global.security.jwt.TokenProvider
@@ -44,7 +45,8 @@ class SignInEmailAndPasswordServiceImpl(
                 accessToken,
                 refreshToken,
                 accessExp,
-                refreshExp
+                refreshExp,
+                member.roles
             )
         } else {
             throw PasswordMismatchException()
@@ -55,12 +57,14 @@ class SignInEmailAndPasswordServiceImpl(
         accessToken: String,
         refreshToken: String,
         accessExp: ZonedDateTime,
-        refreshExp: ZonedDateTime
+        refreshExp: ZonedDateTime,
+        roles: MutableList<Role>
     ): SignInResDto =
         SignInResDto(
             accessToken = accessToken,
             refreshToken = refreshToken,
             accessExp = accessExp,
-            refreshExp = refreshExp
+            refreshExp = refreshExp,
+            roles = roles
         )
 }

--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignInEmailAndPasswordServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignInEmailAndPasswordServiceImpl.kt
@@ -31,6 +31,7 @@ class SignInEmailAndPasswordServiceImpl(
             val accessToken =
                 tokenProvider.generateAccessToken(signInEmailAndPasswordDto.email, role = member.roles.first())
             val accessExp = tokenProvider.accessExpiredTime
+            val expiresAt = tokenProvider.accessExpiredTime
             val refreshToken =
                 tokenProvider.generateRefreshToken(signInEmailAndPasswordDto.email, role = member.roles.first())
             val refreshExp = tokenProvider.refreshExpiredTime
@@ -46,7 +47,8 @@ class SignInEmailAndPasswordServiceImpl(
                 refreshToken,
                 accessExp,
                 refreshExp,
-                member.roles
+                member.roles,
+                expiresAt
             )
         } else {
             throw PasswordMismatchException()
@@ -58,13 +60,15 @@ class SignInEmailAndPasswordServiceImpl(
         refreshToken: String,
         accessExp: ZonedDateTime,
         refreshExp: ZonedDateTime,
-        roles: MutableList<Role>
+        roles: MutableList<Role>,
+        expiresAt: ZonedDateTime
     ): SignInResDto =
         SignInResDto(
             accessToken = accessToken,
             refreshToken = refreshToken,
             accessExp = accessExp,
             refreshExp = refreshExp,
-            roles = roles
+            roles = roles,
+            expiresAt = expiresAt
         )
 }

--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignInGAuthServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignInGAuthServiceImpl.kt
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.ZonedDateTime
+import java.util.*
 
 @Service
 @Transactional(rollbackFor = [Exception::class])
@@ -67,7 +68,8 @@ class SignInGAuthServiceImpl(
                 accessToken = accessToken,
                 refreshToken = refreshToken,
                 accessExp = accessExp,
-                refreshExp = refreshExp
+                refreshExp = refreshExp,
+                roles = Collections.singletonList(role)
             )
         }.getOrElse { error ->
             when (error) {

--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignInGAuthServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignInGAuthServiceImpl.kt
@@ -69,7 +69,8 @@ class SignInGAuthServiceImpl(
                 refreshToken = refreshToken,
                 accessExp = accessExp,
                 refreshExp = refreshExp,
-                roles = Collections.singletonList(role)
+                roles = Collections.singletonList(role),
+                expiresAt = accessExp
             )
         }.getOrElse { error ->
             when (error) {

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/RefreshTokenControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/RefreshTokenControllerTest.kt
@@ -5,6 +5,7 @@ import com.dotori.v2.domain.auth.util.AuthConverter
 import com.dotori.v2.domain.auth.util.impl.AuthConverterImpl
 import com.dotori.v2.domain.auth.presentation.data.res.RefreshResDto
 import com.dotori.v2.domain.auth.service.*
+import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.service.ChangePasswordService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -14,6 +15,7 @@ import io.mockk.verify
 import org.springframework.context.annotation.Bean
 import org.springframework.http.HttpStatus
 import java.time.ZonedDateTime
+import java.util.*
 
 class RefreshTokenControllerTest : BehaviorSpec({
 
@@ -48,7 +50,8 @@ class RefreshTokenControllerTest : BehaviorSpec({
                 accessToken = "thisIsAccess",
                 refreshToken = "thisIsRefresh",
                 accessExp = ZonedDateTime.now(),
-                refreshExp = ZonedDateTime.now()
+                refreshExp = ZonedDateTime.now(),
+                roles = Collections.singletonList(Role.ROLE_DEVELOPER)
             )
 
             val response = authController.getNewRefreshToken(refreshToken)

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/RefreshTokenControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/RefreshTokenControllerTest.kt
@@ -51,7 +51,8 @@ class RefreshTokenControllerTest : BehaviorSpec({
                 refreshToken = "thisIsRefresh",
                 accessExp = ZonedDateTime.now(),
                 refreshExp = ZonedDateTime.now(),
-                roles = Collections.singletonList(Role.ROLE_DEVELOPER)
+                roles = Collections.singletonList(Role.ROLE_DEVELOPER),
+                expiresAt = ZonedDateTime.now()
             )
 
             val response = authController.getNewRefreshToken(refreshToken)

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/SignInControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/SignInControllerTest.kt
@@ -53,7 +53,8 @@ class SignInControllerTest : BehaviorSpec({
                 refreshToken = "thisIsRefresh",
                 accessExp = ZonedDateTime.now(),
                 refreshExp = ZonedDateTime.now(),
-                roles = Collections.singletonList(Role.ROLE_DEVELOPER)
+                roles = Collections.singletonList(Role.ROLE_DEVELOPER),
+                expiresAt = ZonedDateTime.now()
             )
             val response = authController.signInGAuth(request)
 

--- a/src/test/kotlin/com/dotori/v2/domain/member/controller/SignInControllerTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/controller/SignInControllerTest.kt
@@ -7,6 +7,7 @@ import com.dotori.v2.domain.auth.presentation.data.dto.SignInGAuthDto
 import com.dotori.v2.domain.auth.presentation.data.req.SignInGAuthReqDto
 import com.dotori.v2.domain.auth.presentation.data.res.SignInResDto
 import com.dotori.v2.domain.auth.service.*
+import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.service.ChangePasswordService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -16,6 +17,7 @@ import io.mockk.verify
 import org.springframework.context.annotation.Bean
 import org.springframework.http.HttpStatus
 import java.time.ZonedDateTime
+import java.util.*
 
 class SignInControllerTest : BehaviorSpec({
     @Bean
@@ -50,7 +52,8 @@ class SignInControllerTest : BehaviorSpec({
                 accessToken = "thisIsAccess",
                 refreshToken = "thisIsRefresh",
                 accessExp = ZonedDateTime.now(),
-                refreshExp = ZonedDateTime.now()
+                refreshExp = ZonedDateTime.now(),
+                roles = Collections.singletonList(Role.ROLE_DEVELOPER)
             )
             val response = authController.signInGAuth(request)
 

--- a/src/test/kotlin/com/dotori/v2/domain/member/service/RefreshTokenServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/service/RefreshTokenServiceTest.kt
@@ -36,6 +36,7 @@ class RefreshTokenServiceTest : BehaviorSpec({
         val role = Role.ROLE_MEMBER
         val accessExp = ZonedDateTime.now()
         val refreshExp = ZonedDateTime.now()
+        val expiresAt = accessExp
         val email = "s22034@gsm.hs.kr"
         val member = MemberUtil.createMember(email = email)
 
@@ -74,6 +75,7 @@ class RefreshTokenServiceTest : BehaviorSpec({
                 value.accessExp shouldBe accessExp
                 value.refreshExp shouldBe refreshExp
                 value.roles shouldBe member.roles
+                value.expiresAt shouldBe expiresAt
             }
         }
     }

--- a/src/test/kotlin/com/dotori/v2/domain/member/service/RefreshTokenServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/service/RefreshTokenServiceTest.kt
@@ -4,7 +4,9 @@ import com.dotori.v2.domain.auth.domain.entity.RefreshToken
 import com.dotori.v2.domain.auth.domain.repository.RefreshTokenRepository
 import com.dotori.v2.domain.auth.service.impl.RefreshTokenServiceImpl
 import com.dotori.v2.domain.auth.util.AuthConverter
+import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.enums.Role
+import com.dotori.v2.domain.member.util.MemberUtil
 import com.dotori.v2.global.security.jwt.TokenProvider
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -16,12 +18,14 @@ class RefreshTokenServiceTest : BehaviorSpec({
 
     val tokenProvider = mockk<TokenProvider>()
     val refreshTokenRepository = mockk<RefreshTokenRepository>()
+    val memberRepository = mockk<MemberRepository>()
     val authConverter = mockk<AuthConverter>()
 
     val refreshTokenService = RefreshTokenServiceImpl(
         tokenProvider = tokenProvider,
         refreshTokenRepository = refreshTokenRepository,
         authConverter = authConverter,
+        memberRepository = memberRepository
     )
 
     given("refresh 토큰이 주어졌을때") {
@@ -33,6 +37,7 @@ class RefreshTokenServiceTest : BehaviorSpec({
         val accessExp = ZonedDateTime.now()
         val refreshExp = ZonedDateTime.now()
         val email = "s22034@gsm.hs.kr"
+        val member = MemberUtil.createMember(email = email)
 
         every { tokenProvider.parseToken(refreshToken) } returns refreshToken
         every { tokenProvider.exactEmailFromRefreshToken(refreshToken) } returns email
@@ -43,8 +48,10 @@ class RefreshTokenServiceTest : BehaviorSpec({
             token = refreshToken
         )
 
+
         every { refreshTokenRepository.findByToken(refreshToken) } returns refreshTokenEntity
 
+        every { memberRepository.findByEmail(email) } returns member
         every { tokenProvider.generateAccessToken(email, role) } returns accessToken
         every { tokenProvider.generateRefreshToken(email, role) } returns newRefreshToken
         every { tokenProvider.accessExpiredTime } returns accessExp
@@ -66,6 +73,7 @@ class RefreshTokenServiceTest : BehaviorSpec({
                 value.refreshToken shouldBe newRefreshToken
                 value.accessExp shouldBe accessExp
                 value.refreshExp shouldBe refreshExp
+                value.roles shouldBe member.roles
             }
         }
     }

--- a/src/test/kotlin/com/dotori/v2/domain/member/service/SignInServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/member/service/SignInServiceTest.kt
@@ -114,6 +114,7 @@ class SignInServiceTest : BehaviorSpec({
 
         val accessExp = tokenProvider.accessExpiredTime
         val refreshExp = tokenProvider.refreshExpiredTime
+        val expiresAt = tokenProvider.accessExpiredTime
 
         every {
             tokenProvider.accessExpiredTime
@@ -196,6 +197,8 @@ class SignInServiceTest : BehaviorSpec({
                 result.refreshToken shouldBe refreshToken
                 result.accessExp shouldBe accessExp
                 result.refreshExp shouldBe refreshExp
+                result.roles shouldBe member.roles
+                result.expiresAt shouldBe expiresAt
             }
         }
 

--- a/src/test/kotlin/com/dotori/v2/testUtil/AuthDataUtil.kt
+++ b/src/test/kotlin/com/dotori/v2/testUtil/AuthDataUtil.kt
@@ -21,13 +21,15 @@ object AuthDataUtil {
         refreshToken: String,
         accessExp: ZonedDateTime,
         refreshExp: ZonedDateTime,
-        roles: MutableList<Role>
+        roles: MutableList<Role>,
+        expiresAt: ZonedDateTime
     ) = SignInResDto(
         accessToken = accessToken,
         refreshToken = refreshToken,
         accessExp = accessExp,
         refreshExp = refreshExp,
-        roles = roles
+        roles = roles,
+        expiresAt = expiresAt
     )
 
     fun entity(memberId: Long) =

--- a/src/test/kotlin/com/dotori/v2/testUtil/AuthDataUtil.kt
+++ b/src/test/kotlin/com/dotori/v2/testUtil/AuthDataUtil.kt
@@ -4,6 +4,7 @@ import com.dotori.v2.domain.auth.domain.entity.RefreshToken
 import com.dotori.v2.domain.auth.presentation.data.dto.SignInGAuthDto
 import com.dotori.v2.domain.auth.presentation.data.req.SignInGAuthReqDto
 import com.dotori.v2.domain.auth.presentation.data.res.SignInResDto
+import com.dotori.v2.domain.member.enums.Role
 import java.time.ZonedDateTime
 
 object AuthDataUtil {
@@ -19,12 +20,14 @@ object AuthDataUtil {
         accessToken: String,
         refreshToken: String,
         accessExp: ZonedDateTime,
-        refreshExp: ZonedDateTime
+        refreshExp: ZonedDateTime,
+        roles: MutableList<Role>
     ) = SignInResDto(
         accessToken = accessToken,
         refreshToken = refreshToken,
         accessExp = accessExp,
-        refreshExp = refreshExp
+        refreshExp = refreshExp,
+        roles = roles
     )
 
     fun entity(memberId: Long) =


### PR DESCRIPTION
💡 개요
+ 토큰을 반환하는 response에 필드 추가

📃 작업내용
+ `RefreshResDto` , `SignInResDto`에 roles라는 필드를 추가하였습니다.

🙋‍♂️ 질문사항
+ `expiresAt` 이라는 필드도 함께 반환해달라고 요청하셨는데 이미 각 Dto들에서 `expiresAt`에서 반환하는 accessToken의 만료기간을 반환해줘서 일단을 추가시키지 않았습니다. 혹시 현재 dto에서 `expiresAt`필드가 추가로 필요하다면 말씀해주세요.