### PR TITLE
add :: mysql connector dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     implementation(Dependencies.GAUTH)
     implementation(Dependencies.ACTUATOR)
     implementation(Dependencies.PROMETHEUS)
+    implementation(Dependencies.MYSQL)
 }
 
 tasks.withType<KotlinCompile> {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -17,9 +17,10 @@ object Dependencies {
     const val KOTLIN_REFLECT = "org.jetbrains.kotlin:kotlin-reflect"
     const val KOTLIN_STDLIB = "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
-    // h2
+    // db
     const val H2_DATABASE = "com.h2database:h2"
     const val MARIA_DATABASE = "org.mariadb.jdbc:mariadb-java-client"
+    const val MYSQL = "mysql:mysql-connector-java"
 
     // test
     const val SPRING_TEST = "org.springframework.boot:spring-boot-starter-test"


### PR DESCRIPTION
💡 개요
개발서버 mysql 컨테이너로 디비 이전했는데 driver class name을 못 읽더라고요
mysql connector 의존성이 없어서 그런 것 같습니다.

<img width="882" alt="image" src="https://github.com/Team-Ampersand/Dotori-server-V2/assets/105429536/e32d2fd0-ba6d-42a8-b8bb-269bb9a19032">
