### PR TITLE
Update YoutubeServiceImpl.kt

### DIFF
--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/service/impl/YoutubeServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/service/impl/YoutubeServiceImpl.kt
@@ -33,7 +33,7 @@ class YoutubeServiceImpl(
      * YouTube videoId를 추출하는 로직입니다.
      */
     private fun extractVideoId(url: String): String {
-        val pattern = Regex("""^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(-nocookie)?\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|live\/|v\/)?)([\w\-]+)(\S+)?$""")
+        val pattern = Regex("""^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(-nocookie)?\.com|youtu\.be))(\/(?:[\w\-]+\?v=|embed\/|live\/|v\/)?)([\w\-]+)(\S+)?$""")
         return pattern.find(url)?.groupValues?.get(6) ?: throw NotValidUrlException()
     }
 }

--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/service/impl/YoutubeServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/service/impl/YoutubeServiceImpl.kt
@@ -33,7 +33,7 @@ class YoutubeServiceImpl(
      * YouTube videoId를 추출하는 로직입니다.
      */
     private fun extractVideoId(url: String): String {
-        val pattern = Regex("""https?://(?:youtu\.be/|(?:[a-z]{2,3}\.)?youtube\.com/watch(?:\?|#\!)v=)([\w-]{11}).*""")
+        val pattern = Regex("""^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(-nocookie)?\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|live\/|v\/)?)([\w\-]+)(\S+)?$""")
         return pattern.find(url)?.groupValues?.get(1) ?: throw NotValidUrlException()
     }
 }

--- a/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/service/impl/YoutubeServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/global/thirdparty/youtube/service/impl/YoutubeServiceImpl.kt
@@ -34,6 +34,6 @@ class YoutubeServiceImpl(
      */
     private fun extractVideoId(url: String): String {
         val pattern = Regex("""^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(-nocookie)?\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|live\/|v\/)?)([\w\-]+)(\S+)?$""")
-        return pattern.find(url)?.groupValues?.get(1) ?: throw NotValidUrlException()
+        return pattern.find(url)?.groupValues?.get(6) ?: throw NotValidUrlException()
     }
 }


### PR DESCRIPTION
💡 개요
**서비스의 기상음악 관련 CSRF 취약점을 보완했습니다.**

https://www.dotori-gsm.com/song

2024-02-21의 1106 김주은의 기상음악을 접속해 보면 naver 링크로 이동됩니다.

해당 url을 살펴보면

![image](https://github.com/Jueuunn7/Dotori-server-V2/assets/132628016/bf4dab3c-fcff-48ba-8cb3-99b727a1d20e)

위와 같이 fragment를 사용해서 정규식을 우회할 수 있으며 공격자가 원하는 서버로 보낼 수 있는 문제가 발생합니다.

다른 형식들도 가능한 것을 확인할 수 있습니다
https://www.naver.com/?https://www.youtube.com/watch?v=EVJjmMW7eII
https://www.naver.com/\https://www.youtube.com/watch?v=EVJjmMW7eII

📃 작업내용
- Youtube URL 유효성 검증 정규식을 수정하였습니다
