### PR TITLE
fix :: exist member

### DIFF
--- a/src/main/kotlin/com/dotori/v2/global/config/dev/DevMemberConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/dev/DevMemberConfig.kt
@@ -28,7 +28,8 @@ class DevMemberConfig(
             ruleViolation = mutableListOf(),
             profileImage = null
         )
-        memberRepository.save(admin)
+        if(!memberRepository.existMemberByEmail(admin.email))
+            memberRepository.save(admin)
 
         val developer = Member(
             memberName = "도토리개발자",
@@ -40,7 +41,8 @@ class DevMemberConfig(
             ruleViolation = mutableListOf(),
             profileImage = null
         )
-        memberRepository.save(developer)
+        if(!memberRepository.existMemberByEmail(developer.email))
+            memberRepository.save(developer)
 
         val councillor = Member(
             memberName = "기숙사자치위원",
@@ -52,7 +54,8 @@ class DevMemberConfig(
             ruleViolation = mutableListOf(),
             profileImage = null
         )
-        memberRepository.save(councillor)
+        if(!memberRepository.existMemberByEmail(councillor.email))
+            memberRepository.save(councillor)
 
         val man = Member(
             memberName = "남성유저",
@@ -64,7 +67,8 @@ class DevMemberConfig(
             ruleViolation = mutableListOf(),
             profileImage = null
         )
-        memberRepository.save(man)
+        if(!memberRepository.existMemberByEmail(man.email))
+            memberRepository.save(man)
 
         val woman = Member(
             memberName = "여성유저",
@@ -76,6 +80,7 @@ class DevMemberConfig(
             ruleViolation = mutableListOf(),
             profileImage = null
         )
-        memberRepository.save(woman)
+        if(!memberRepository.existMemberByEmail(woman.email))
+            memberRepository.save(woman)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/global/config/dev/DevMemberConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/dev/DevMemberConfig.kt
@@ -16,71 +16,76 @@ class DevMemberConfig(
     private val passwordEncoder: PasswordEncoder
 ) {
     @PostConstruct
-    fun generateMember(){
+    fun generateMember() {
         val password = passwordEncoder.encode("string1!")!!
-        val admin = Member(
-            memberName = "사감선생님",
-            stuNum = "0000",
-            email = "s00000@gsm.hs.kr",
-            password = password,
-            gender = Gender.PENDING,
-            roles = mutableListOf(Role.ROLE_ADMIN),
-            ruleViolation = mutableListOf(),
-            profileImage = null
-        )
-        if(!memberRepository.existMemberByEmail(admin.email))
+        if (!memberRepository.existsById(1)) {
+            val admin = Member(
+                memberName = "사감선생님",
+                stuNum = "0000",
+                email = "s00000@gsm.hs.kr",
+                password = password,
+                gender = Gender.PENDING,
+                roles = mutableListOf(Role.ROLE_ADMIN),
+                ruleViolation = mutableListOf(),
+                profileImage = null
+            )
             memberRepository.save(admin)
+        }
 
-        val developer = Member(
-            memberName = "도토리개발자",
-            stuNum = "0001",
-            email = "s00001@gsm.hs.kr",
-            password = password,
-            gender = Gender.PENDING,
-            roles = mutableListOf(Role.ROLE_DEVELOPER),
-            ruleViolation = mutableListOf(),
-            profileImage = null
-        )
-        if(!memberRepository.existMemberByEmail(developer.email))
+        if (!memberRepository.existsById(2)) {
+            val developer = Member(
+                memberName = "도토리개발자",
+                stuNum = "0001",
+                email = "s00001@gsm.hs.kr",
+                password = password,
+                gender = Gender.PENDING,
+                roles = mutableListOf(Role.ROLE_DEVELOPER),
+                ruleViolation = mutableListOf(),
+                profileImage = null
+            )
             memberRepository.save(developer)
+        }
 
-        val councillor = Member(
-            memberName = "기숙사자치위원",
-            stuNum = "0002",
-            email = "s00002@gsm.hs.kr",
-            password = password,
-            gender = Gender.PENDING,
-            roles = mutableListOf(Role.ROLE_COUNCILLOR),
-            ruleViolation = mutableListOf(),
-            profileImage = null
-        )
-        if(!memberRepository.existMemberByEmail(councillor.email))
+        if (!memberRepository.existsById(3)) {
+            val councillor = Member(
+                memberName = "기숙사자치위원",
+                stuNum = "0002",
+                email = "s00002@gsm.hs.kr",
+                password = password,
+                gender = Gender.PENDING,
+                roles = mutableListOf(Role.ROLE_COUNCILLOR),
+                ruleViolation = mutableListOf(),
+                profileImage = null
+            )
             memberRepository.save(councillor)
+        }
 
-        val man = Member(
-            memberName = "남성유저",
-            stuNum = "3101",
-            email = "s00003@gsm.hs.kr",
-            password = password,
-            gender = Gender.PENDING,
-            roles = mutableListOf(Role.ROLE_MEMBER),
-            ruleViolation = mutableListOf(),
-            profileImage = null
-        )
-        if(!memberRepository.existMemberByEmail(man.email))
+        if (!memberRepository.existsById(4)) {
+            val man = Member(
+                memberName = "남성유저",
+                stuNum = "3101",
+                email = "s00003@gsm.hs.kr",
+                password = password,
+                gender = Gender.PENDING,
+                roles = mutableListOf(Role.ROLE_MEMBER),
+                ruleViolation = mutableListOf(),
+                profileImage = null
+            )
             memberRepository.save(man)
+        }
 
-        val woman = Member(
-            memberName = "여성유저",
-            stuNum = "3201",
-            email = "s00004@gsm.hs.kr",
-            password = password,
-            gender = Gender.PENDING,
-            roles = mutableListOf(Role.ROLE_MEMBER),
-            ruleViolation = mutableListOf(),
-            profileImage = null
-        )
-        if(!memberRepository.existMemberByEmail(woman.email))
+        if (!memberRepository.existsById(5)) {
+            val woman = Member(
+                memberName = "여성유저",
+                stuNum = "3201",
+                email = "s00004@gsm.hs.kr",
+                password = password,
+                gender = Gender.PENDING,
+                roles = mutableListOf(Role.ROLE_MEMBER),
+                ruleViolation = mutableListOf(),
+                profileImage = null
+            )
             memberRepository.save(woman)
+        }
     }
 }


### PR DESCRIPTION
💡 개요
 
중복된 pk의 유저 데이터를 저장하기 때문에 오류가 발생하여 exists문을 사용하여 해당 아이디의 엔티티가 존재하지 않을때만 데이터를 삽입하게 만들었습니다.

📃 작업내용

- 중복 유저 확인
