### PR TITLE
#342 예약 api 지표 분석, 저장 기능 개발

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -14,6 +14,6 @@ permissions:
 
 hooks:
   ApplicationStart:
-    - location: ./deploy-dev.sh
+    - location: ./deploy-execution.sh
       timeout: 60
       runas: ubuntu

--- a/src/main/kotlin/com/dotori/v2/domain/massage/service/impl/ApplyMassageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/massage/service/impl/ApplyMassageServiceImpl.kt
@@ -8,6 +8,7 @@ import com.dotori.v2.domain.massage.util.SaveMassageUtil
 import com.dotori.v2.domain.massage.util.ValidDayOfWeekAndHourMassageUtil
 import com.dotori.v2.domain.member.enums.MassageStatus
 import com.dotori.v2.global.util.UserUtil
+import com.dotori.v2.indicator.IndicatorTarget
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
@@ -21,6 +22,8 @@ class ApplyMassageServiceImpl(
     private val saveMassageUtil: SaveMassageUtil,
     private val massageCheckUtil: MassageCheckUtil,
 ) : ApplyMassageService {
+
+    @IndicatorTarget
     override fun execute() {
         validDayOfWeekAndHourMassageUtil.validateApply()
 

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/ApplySelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/ApplySelfStudyServiceImpl.kt
@@ -8,6 +8,7 @@ import com.dotori.v2.domain.selfstudy.util.SaveSelfStudyUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
 import com.dotori.v2.global.util.UserUtil
+import com.dotori.v2.indicator.IndicatorTarget
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
@@ -21,6 +22,8 @@ class ApplySelfStudyServiceImpl(
     private val saveSelfStudyUtil: SaveSelfStudyUtil,
     private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil
 ) : ApplySelfStudyService{
+
+    @IndicatorTarget
     override fun execute() {
         validDayOfWeekAndHourUtil.validateApply()
 

--- a/src/main/kotlin/com/dotori/v2/indicator/Indicate.kt
+++ b/src/main/kotlin/com/dotori/v2/indicator/Indicate.kt
@@ -1,0 +1,5 @@
+package com.dotori.v2.indicator
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Indicate

--- a/src/main/kotlin/com/dotori/v2/indicator/IndicatorTarget.kt
+++ b/src/main/kotlin/com/dotori/v2/indicator/IndicatorTarget.kt
@@ -2,4 +2,4 @@ package com.dotori.v2.indicator
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Indicate
+annotation class IndicatorTarget

--- a/src/main/kotlin/com/dotori/v2/indicator/ReservationCategory.kt
+++ b/src/main/kotlin/com/dotori/v2/indicator/ReservationCategory.kt
@@ -1,0 +1,5 @@
+package com.dotori.v2.indicator
+
+enum class ReservationCategory {
+    SELFSTUDY, MASSAGE
+}

--- a/src/main/kotlin/com/dotori/v2/indicator/ReservationIndicatorAspect.kt
+++ b/src/main/kotlin/com/dotori/v2/indicator/ReservationIndicatorAspect.kt
@@ -1,0 +1,70 @@
+package com.dotori.v2.indicator
+
+import com.dotori.v2.global.error.ErrorCode
+import com.dotori.v2.global.error.exception.BasicException
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Aspect
+@Component
+class ReservationIndicatorAspect(
+    private val reservationIndicatorsRepository: ReservationIndicatorsRepository
+) {
+
+    @Around("@annotation(com.dotori.v2.indicator.Indicate)")
+    fun indicateLatency(joinPoint: ProceedingJoinPoint): Any? {
+        val currentTime = LocalDateTime.now()
+        val startHour = 8
+        val endHour = 9
+
+        return if(currentTime.hour in startHour .. endHour) {
+            val startMillis = System.currentTimeMillis()
+
+            val userId = SecurityContextHolder.getContext().authentication.name.toLong()
+            var result: Any? = null
+            var status: ResultStatus
+            val reservationCategory: ReservationCategory
+
+            try {
+                result = joinPoint.proceed()
+                status = ResultStatus.SUCCESS
+            } catch(e: BasicException) {
+                status = ResultStatus.FAILED
+            }
+
+            val endTime = LocalDateTime.now()
+            val duration = System.currentTimeMillis() - startMillis
+            val signatureName = joinPoint.signature.declaringType.simpleName
+            reservationCategory = when (signatureName) {
+                "ApplySelfStudyService" -> {
+                    ReservationCategory.SELFSTUDY
+                }
+                "ApplyMassageService" -> {
+                    ReservationCategory.MASSAGE
+                }
+                else -> {
+                    throw BasicException(ErrorCode.UNKNOWN_ERROR)
+                }
+            }
+
+            val reservationIndicators = ReservationIndicators(
+                userId = userId,
+                requestTime = currentTime,
+                responseTime = endTime,
+                latencyMs = duration,
+                resultStatus = status,
+                reservationCategory = reservationCategory
+            )
+
+            reservationIndicatorsRepository.save(reservationIndicators)
+            result
+        } else {
+            joinPoint.proceed()
+        }
+    }
+
+}

--- a/src/main/kotlin/com/dotori/v2/indicator/ReservationIndicatorAspect.kt
+++ b/src/main/kotlin/com/dotori/v2/indicator/ReservationIndicatorAspect.kt
@@ -7,6 +7,7 @@ import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.time.LocalDateTime
 
 @Aspect
@@ -22,8 +23,6 @@ class ReservationIndicatorAspect(
         val endHour = 9
 
         return if(currentTime.hour in startHour .. endHour) {
-            val startMillis = System.currentTimeMillis()
-
             val userId = SecurityContextHolder.getContext().authentication.name.toLong()
             var result: Any? = null
             var status: ResultStatus
@@ -37,7 +36,7 @@ class ReservationIndicatorAspect(
             }
 
             val endTime = LocalDateTime.now()
-            val duration = System.currentTimeMillis() - startMillis
+            val duration = Duration.between(currentTime, endTime).toMillis()
             val signatureName = joinPoint.signature.declaringType.simpleName
             reservationCategory = when (signatureName) {
                 "ApplySelfStudyService" -> {

--- a/src/main/kotlin/com/dotori/v2/indicator/ReservationIndicatorAspect.kt
+++ b/src/main/kotlin/com/dotori/v2/indicator/ReservationIndicatorAspect.kt
@@ -15,7 +15,7 @@ class ReservationIndicatorAspect(
     private val reservationIndicatorsRepository: ReservationIndicatorsRepository
 ) {
 
-    @Around("@annotation(com.dotori.v2.indicator.Indicate)")
+    @Around("@annotation(com.dotori.v2.indicator.IndicatorTarget)")
     fun indicateLatency(joinPoint: ProceedingJoinPoint): Any? {
         val currentTime = LocalDateTime.now()
         val startHour = 8

--- a/src/main/kotlin/com/dotori/v2/indicator/ReservationIndicators.kt
+++ b/src/main/kotlin/com/dotori/v2/indicator/ReservationIndicators.kt
@@ -1,0 +1,28 @@
+package com.dotori.v2.indicator
+
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import java.time.LocalDateTime
+
+@Entity
+class ReservationIndicators(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    val id: Long = 0,
+
+    val userId: Long,
+
+    val requestTime: LocalDateTime,
+
+    val responseTime: LocalDateTime,
+
+    val latencyMs: Long,
+
+    val resultStatus: ResultStatus,
+
+    val reservationCategory: ReservationCategory
+)

--- a/src/main/kotlin/com/dotori/v2/indicator/ReservationIndicatorsRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/indicator/ReservationIndicatorsRepository.kt
@@ -1,0 +1,6 @@
+package com.dotori.v2.indicator
+
+import org.springframework.data.repository.CrudRepository
+
+interface ReservationIndicatorsRepository : CrudRepository<ReservationIndicators, Long> {
+}

--- a/src/main/kotlin/com/dotori/v2/indicator/ResultStatus.kt
+++ b/src/main/kotlin/com/dotori/v2/indicator/ResultStatus.kt
@@ -1,0 +1,5 @@
+package com.dotori.v2.indicator
+
+enum class ResultStatus {
+    SUCCESS, FAILED
+}


### PR DESCRIPTION
### Description

8 ~ 9시 열리는 reservation api에 대한 request time, response time, latency 지표 정보들을 disk에 저장하는 기능을 개발했습니다.

\+ 현재는 request가 올 때마다 entity를 save합니다. 하나하나 세이브를 하지 말고 buffer에 담아뒀다가 한번에 flush하는 방법도 괜찮을 듯 싶습니다.

> 1.차후 조회하는 api에서 latency 별로 sort할지 request time별로 sort할지에 대한 여부도 체크해야합니다.
> 2. 테스트를 작성해야합니다. aop 시나리오를 제대로 테스트할 방법을 찾아야합니다.