### PR TITLE
학생정보 어드민 API에 캐시 기능 추가

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignUpServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignUpServiceImpl.kt
@@ -5,9 +5,12 @@ import com.dotori.v2.domain.auth.service.SignUpService
 import com.dotori.v2.domain.email.domain.repository.EmailCertificateRepository
 import com.dotori.v2.domain.email.exception.EmailAuthNotFoundException
 import com.dotori.v2.domain.email.exception.EmailNotBeenException
+import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
+import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.exception.MemberAlreadyException
-import org.springframework.cache.annotation.CacheEvict
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentResDto
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -18,8 +21,8 @@ class SignUpServiceImpl(
     private val emailCertificateRepository: EmailCertificateRepository,
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder,
+    private val redisCacheService: RedisCacheService
 ): SignUpService {
-    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(signUpReqDto: SignUpReqDto) {
         val emailCertificate = emailCertificateRepository.findByEmail(signUpReqDto.email)
             ?: throw EmailAuthNotFoundException()
@@ -36,5 +39,29 @@ class SignUpServiceImpl(
         val member = signUpReqDto.toEntity(encodedPassword)
 
         memberRepository.save(member)
+
+        updateCache(member)
+    }
+
+    private fun updateCache(member: Member) {
+        val cacheKey = "memberList"
+        val cachedData = redisCacheService.getFromCache(cacheKey) as? List<FindAllStudentResDto>
+
+        if (cachedData != null) {
+            val updatedList = cachedData.toMutableList().apply {
+                add(
+                    FindAllStudentResDto(
+                        id = member.id,
+                        gender = member.gender,
+                        memberName = member.memberName,
+                        stuNum = member.stuNum,
+                        role = Role.ROLE_MEMBER,
+                        selfStudyStatus = member.selfStudyStatus,
+                        profileImage = null
+                    )
+                )
+            }
+            redisCacheService.putToCache(cacheKey, updatedList)
+        }
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignUpServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignUpServiceImpl.kt
@@ -7,6 +7,7 @@ import com.dotori.v2.domain.email.exception.EmailAuthNotFoundException
 import com.dotori.v2.domain.email.exception.EmailNotBeenException
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.exception.MemberAlreadyException
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -18,6 +19,7 @@ class SignUpServiceImpl(
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder,
 ): SignUpService {
+    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(signUpReqDto: SignUpReqDto) {
         val emailCertificate = emailCertificateRepository.findByEmail(signUpReqDto.email)
             ?: throw EmailAuthNotFoundException()

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/DeleteProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/DeleteProfileImageServiceImpl.kt
@@ -3,6 +3,7 @@ package com.dotori.v2.domain.member.service.impl
 import com.dotori.v2.domain.member.service.DeleteProfileImageService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,7 +13,7 @@ class DeleteProfileImageServiceImpl(
     private val userUtil: UserUtil,
     private val s3Service: S3Service
 ) : DeleteProfileImageService {
-
+    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute() {
         val member = userUtil.fetchCurrentUser()
         s3Service.deleteFile(member.profileImage!!)

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/DeleteProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/DeleteProfileImageServiceImpl.kt
@@ -1,9 +1,9 @@
 package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.service.DeleteProfileImageService
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -11,13 +11,14 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(rollbackFor = [Exception::class])
 class DeleteProfileImageServiceImpl(
     private val userUtil: UserUtil,
-    private val s3Service: S3Service
+    private val s3Service: S3Service,
+    private val redisCacheService: RedisCacheService
 ) : DeleteProfileImageService {
-    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute() {
         val member = userUtil.fetchCurrentUser()
         s3Service.deleteFile(member.profileImage!!)
         member.updateProfileImage(null)
-    }
 
+        redisCacheService.updateCacheFromProfile(member.id, null)
+    }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -3,6 +3,7 @@ package com.dotori.v2.domain.member.service.impl
 import com.dotori.v2.domain.member.service.UpdateProfileImageService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -13,6 +14,7 @@ class UpdateProfileImageServiceImpl(
     private val userUtil: UserUtil,
     private val s3Service: S3Service
 ): UpdateProfileImageService {
+    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(multipartFiles: MultipartFile?) {
         val member = userUtil.fetchCurrentUser()
         var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -1,9 +1,9 @@
 package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.service.UpdateProfileImageService
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -12,13 +12,15 @@ import org.springframework.web.multipart.MultipartFile
 @Transactional(rollbackFor = [Exception::class])
 class UpdateProfileImageServiceImpl(
     private val userUtil: UserUtil,
-    private val s3Service: S3Service
+    private val s3Service: S3Service,
+    private val redisCacheService: RedisCacheService
 ): UpdateProfileImageService {
-    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(multipartFiles: MultipartFile?) {
         val member = userUtil.fetchCurrentUser()
         var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
         s3Service.deleteFile(member.profileImage!!)
         member.updateProfileImage(uploadFile)
+
+        redisCacheService.updateCacheFromProfile(member.id, uploadFile)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -4,6 +4,7 @@ import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.service.UploadProfileImageService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -14,6 +15,7 @@ class UploadProfileImageServiceImpl(
     private val userUtil: UserUtil,
     private val s3Service: S3Service
 ): UploadProfileImageService {
+    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
         var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -2,9 +2,9 @@ package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.service.UploadProfileImageService
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -13,12 +13,14 @@ import org.springframework.web.multipart.MultipartFile
 @Transactional(rollbackFor = [Exception::class])
 class UploadProfileImageServiceImpl(
     private val userUtil: UserUtil,
-    private val s3Service: S3Service
+    private val s3Service: S3Service,
+    private val redisCacheService: RedisCacheService
 ): UploadProfileImageService {
-    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
         var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
         member.updateProfileImage(uploadFile)
+
+        redisCacheService.updateCacheFromProfile(member.id, uploadFile)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/WithdrawalServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/WithdrawalServiceImpl.kt
@@ -2,9 +2,10 @@ package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.service.WithdrawalService
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentResDto
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,11 +15,23 @@ class WithdrawalServiceImpl(
     private val memberRepository: MemberRepository,
     private val s3Service: S3Service,
     private val userUtil: UserUtil,
+    private val redisCacheService: RedisCacheService
 ) : WithdrawalService {
-    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute() {
         val currentUser = userUtil.fetchCurrentUser()
         currentUser.profileImage?.let { s3Service.deleteFile(it) }
         memberRepository.delete(currentUser)
+
+        evictUserFromCache(currentUser.id)
+    }
+
+    private fun evictUserFromCache(userId: Long) {
+        val cacheKey = "memberList"
+        val cachedData = redisCacheService.getFromCache(cacheKey) as? List<FindAllStudentResDto>
+
+        if (cachedData != null) {
+            val updatedList = cachedData.filterNot { it.id == userId }
+            redisCacheService.putToCache(cacheKey, updatedList)
+        }
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/WithdrawalServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/WithdrawalServiceImpl.kt
@@ -4,6 +4,7 @@ import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.service.WithdrawalService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,6 +15,7 @@ class WithdrawalServiceImpl(
     private val s3Service: S3Service,
     private val userUtil: UserUtil,
 ) : WithdrawalService {
+    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute() {
         val currentUser = userUtil.fetchCurrentUser()
         currentUser.profileImage?.let { s3Service.deleteFile(it) }

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/ApplySelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/ApplySelfStudyServiceImpl.kt
@@ -8,6 +8,7 @@ import com.dotori.v2.domain.selfstudy.util.SaveSelfStudyUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
 import com.dotori.v2.global.util.UserUtil
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
@@ -21,6 +22,7 @@ class ApplySelfStudyServiceImpl(
     private val saveSelfStudyUtil: SaveSelfStudyUtil,
     private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil
 ) : ApplySelfStudyService{
+    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute() {
         validDayOfWeekAndHourUtil.validateApply()
 

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/ApplySelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/ApplySelfStudyServiceImpl.kt
@@ -7,8 +7,8 @@ import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SaveSelfStudyUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
@@ -20,9 +20,9 @@ class ApplySelfStudyServiceImpl(
     private val findSelfStudyCountUtil: FindSelfStudyCountUtil,
     private val selfStudyCheckUtil: SelfStudyCheckUtil,
     private val saveSelfStudyUtil: SaveSelfStudyUtil,
-    private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil
+    private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil,
+    private val redisCacheService: RedisCacheService
 ) : ApplySelfStudyService{
-    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute() {
         validDayOfWeekAndHourUtil.validateApply()
 
@@ -37,5 +37,7 @@ class ApplySelfStudyServiceImpl(
         member.updateSelfStudyStatus(SelfStudyStatus.APPLIED)
         selfStudyCount.addCount()
         saveSelfStudyUtil.save(member)
+
+        redisCacheService.updateCacheFromSelfStudy(member.id, SelfStudyStatus.APPLIED)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/BanSelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/BanSelfStudyServiceImpl.kt
@@ -5,7 +5,7 @@ import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.selfstudy.service.BanSelfStudyService
-import org.springframework.cache.annotation.CacheEvict
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,12 +14,14 @@ import java.time.LocalDateTime
 @Service
 @Transactional(rollbackFor = [Exception::class])
 class BanSelfStudyServiceImpl(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val redisCacheService: RedisCacheService
 ) : BanSelfStudyService {
-    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(id: Long) {
         val member = memberRepository.findByIdOrNull(id) ?: throw MemberNotFoundException()
         updateSelfStudyAndExpiredDate(member, SelfStudyStatus.IMPOSSIBLE, LocalDateTime.now().plusDays(7))
+
+        redisCacheService.updateCacheFromSelfStudy(member.id, SelfStudyStatus.IMPOSSIBLE)
     }
 
     private fun updateSelfStudyAndExpiredDate(

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/BanSelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/BanSelfStudyServiceImpl.kt
@@ -5,6 +5,7 @@ import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.selfstudy.service.BanSelfStudyService
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,6 +16,7 @@ import java.time.LocalDateTime
 class BanSelfStudyServiceImpl(
     private val memberRepository: MemberRepository
 ) : BanSelfStudyService {
+    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(id: Long) {
         val member = memberRepository.findByIdOrNull(id) ?: throw MemberNotFoundException()
         updateSelfStudyAndExpiredDate(member, SelfStudyStatus.IMPOSSIBLE, LocalDateTime.now().plusDays(7))

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/CancelBanSelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/CancelBanSelfStudyServiceImpl.kt
@@ -5,6 +5,7 @@ import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.selfstudy.service.CancelBanSelfStudyService
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,6 +16,7 @@ import java.time.LocalDateTime
 class CancelBanSelfStudyServiceImpl(
     private val memberRepository: MemberRepository
 ) : CancelBanSelfStudyService{
+    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(id: Long) {
         val member = memberRepository.findByIdOrNull(id) ?: throw MemberNotFoundException()
         updateSelfStudyAndExpiredDate(member, SelfStudyStatus.CAN, null)

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/CancelBanSelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/CancelBanSelfStudyServiceImpl.kt
@@ -5,7 +5,7 @@ import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.selfstudy.service.CancelBanSelfStudyService
-import org.springframework.cache.annotation.CacheEvict
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,12 +14,14 @@ import java.time.LocalDateTime
 @Service
 @Transactional(rollbackFor = [Exception::class])
 class CancelBanSelfStudyServiceImpl(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val redisCacheService: RedisCacheService
 ) : CancelBanSelfStudyService{
-    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(id: Long) {
         val member = memberRepository.findByIdOrNull(id) ?: throw MemberNotFoundException()
         updateSelfStudyAndExpiredDate(member, SelfStudyStatus.CAN, null)
+
+        redisCacheService.updateCacheFromSelfStudy(member.id, SelfStudyStatus.CAN)
 
     }
 

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/CancelSelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/CancelSelfStudyServiceImpl.kt
@@ -7,6 +7,7 @@ import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
 import com.dotori.v2.global.util.UserUtil
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,6 +20,7 @@ class CancelSelfStudyServiceImpl(
     private val selfStudyRepository: SelfStudyRepository,
     private val selfStudyCheckUtil: SelfStudyCheckUtil
 ) : CancelSelfStudyService {
+    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute() {
         validDayOfWeekAndHourUtil.validateCancel()
 

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/CancelSelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/CancelSelfStudyServiceImpl.kt
@@ -6,8 +6,8 @@ import com.dotori.v2.domain.selfstudy.service.CancelSelfStudyService
 import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -18,9 +18,9 @@ class CancelSelfStudyServiceImpl(
     private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil,
     private val findSelfStudyCountUtil: FindSelfStudyCountUtil,
     private val selfStudyRepository: SelfStudyRepository,
-    private val selfStudyCheckUtil: SelfStudyCheckUtil
+    private val selfStudyCheckUtil: SelfStudyCheckUtil,
+    private val redisCacheService: RedisCacheService
 ) : CancelSelfStudyService {
-    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute() {
         validDayOfWeekAndHourUtil.validateCancel()
 
@@ -34,5 +34,7 @@ class CancelSelfStudyServiceImpl(
 
         selfStudyRepository.deleteByMember(member)
         findSelfStudyCount.removeCount()
+
+        redisCacheService.updateCacheFromSelfStudy(member.id, SelfStudyStatus.CANT)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/student/presentation/data/res/FindAllStudentResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/student/presentation/data/res/FindAllStudentResDto.kt
@@ -12,4 +12,14 @@ data class FindAllStudentResDto(
     val role: Role,
     val selfStudyStatus: SelfStudyStatus,
     val profileImage: String?
-)
+) {
+    constructor() : this(
+        id = 0L,
+        gender = Gender.MAN,
+        memberName = "",
+        stuNum = "",
+        role = Role.ROLE_ADMIN,
+        selfStudyStatus = SelfStudyStatus.APPLIED,
+        profileImage = ""
+    )
+}

--- a/src/main/kotlin/com/dotori/v2/domain/student/service/impl/FindAllMemberServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/student/service/impl/FindAllMemberServiceImpl.kt
@@ -3,6 +3,7 @@ package com.dotori.v2.domain.student.service.impl
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentResDto
 import com.dotori.v2.domain.student.service.FindAllMemberService
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 class FindAllMemberServiceImpl(
     private val memberRepository: MemberRepository
 ) : FindAllMemberService {
+    @Cacheable(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(): List<FindAllStudentResDto> =
         memberRepository.findAll(Sort.by(Sort.Direction.ASC, "stuNum"))
             .map {

--- a/src/main/kotlin/com/dotori/v2/domain/student/service/impl/FindAllMemberServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/student/service/impl/FindAllMemberServiceImpl.kt
@@ -3,7 +3,7 @@ package com.dotori.v2.domain.student.service.impl
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentResDto
 import com.dotori.v2.domain.student.service.FindAllMemberService
-import org.springframework.cache.annotation.Cacheable
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,21 +12,31 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true, rollbackFor = [Exception::class])
 class FindAllMemberServiceImpl(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val redisCacheService: RedisCacheService
 ) : FindAllMemberService {
-    @Cacheable(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
-    override fun execute(): List<FindAllStudentResDto> =
-        memberRepository.findAll(Sort.by(Sort.Direction.ASC, "stuNum"))
-            .map {
-                FindAllStudentResDto(
-                    id = it.id,
-                    gender = it.gender,
-                    memberName = it.memberName,
-                    stuNum = it.stuNum,
-                    role = it.roles[0],
-                    selfStudyStatus = it.selfStudyStatus,
-                    profileImage = it.profileImage
-                )
-            }
+    override fun execute(): List<FindAllStudentResDto> {
+        val cacheKey = "memberList"
 
+        val cachedData = redisCacheService.getFromCache(cacheKey)
+        if (cachedData != null) {
+            return cachedData as List<FindAllStudentResDto>
+        }
+
+        val members = memberRepository.findAll(Sort.by(Sort.Direction.ASC, "stuNum")).map {
+            FindAllStudentResDto(
+                id = it.id,
+                gender = it.gender,
+                memberName = it.memberName,
+                stuNum = it.stuNum,
+                role = it.roles[0],
+                selfStudyStatus = it.selfStudyStatus,
+                profileImage = it.profileImage
+            )
+        }
+
+        redisCacheService.putToCache(cacheKey, members)
+
+        return members
+    }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/student/service/impl/ModifyStudentInfoServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/student/service/impl/ModifyStudentInfoServiceImpl.kt
@@ -5,6 +5,7 @@ import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.student.presentation.data.req.ModifyStudentInfoRequest
 import com.dotori.v2.domain.student.service.ModifyStudentInfoService
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,6 +16,7 @@ import java.util.*
 class ModifyStudentInfoServiceImpl(
     private val memberRepository: MemberRepository
 ) : ModifyStudentInfoService {
+    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
     override fun execute(modifyStudentInfoRequest: ModifyStudentInfoRequest) {
         val member = memberRepository.findByIdOrNull(modifyStudentInfoRequest.memberId) ?: throw MemberNotFoundException()
         updateMemberInfo(member, modifyStudentInfoRequest)

--- a/src/main/kotlin/com/dotori/v2/domain/student/service/impl/ModifyStudentInfoServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/student/service/impl/ModifyStudentInfoServiceImpl.kt
@@ -4,8 +4,9 @@ import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.student.presentation.data.req.ModifyStudentInfoRequest
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentResDto
 import com.dotori.v2.domain.student.service.ModifyStudentInfoService
-import org.springframework.cache.annotation.CacheEvict
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,12 +15,17 @@ import java.util.*
 @Service
 @Transactional(rollbackFor = [Exception::class])
 class ModifyStudentInfoServiceImpl(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val redisCacheService: RedisCacheService,
 ) : ModifyStudentInfoService {
-    @CacheEvict(cacheNames = ["memberList"], key = "'memberList'", cacheManager = "contentCacheManager")
+
     override fun execute(modifyStudentInfoRequest: ModifyStudentInfoRequest) {
-        val member = memberRepository.findByIdOrNull(modifyStudentInfoRequest.memberId) ?: throw MemberNotFoundException()
+        val member = memberRepository.findByIdOrNull(modifyStudentInfoRequest.memberId)
+            ?: throw MemberNotFoundException()
+
         updateMemberInfo(member, modifyStudentInfoRequest)
+
+        updateCache(modifyStudentInfoRequest)
     }
 
     private fun updateMemberInfo(member: Member, modifyStudentInfoRequest: ModifyStudentInfoRequest) {
@@ -35,5 +41,29 @@ class ModifyStudentInfoServiceImpl(
             profileImage = member.profileImage
         )
         memberRepository.save(newMember)
+    }
+
+    private fun updateCache(modifyStudentInfoRequest: ModifyStudentInfoRequest) {
+        val cacheKey = "memberList"
+        val cachedData = redisCacheService.getFromCache(cacheKey) as? List<FindAllStudentResDto>?
+
+        if (cachedData != null) {
+            val updatedList = cachedData.map {
+                if (it.id == modifyStudentInfoRequest.memberId) {
+                    FindAllStudentResDto(
+                        id = it.id,
+                        gender = modifyStudentInfoRequest.gender,
+                        memberName = modifyStudentInfoRequest.memberName,
+                        stuNum = modifyStudentInfoRequest.stuNum,
+                        role = modifyStudentInfoRequest.role,
+                        selfStudyStatus = it.selfStudyStatus,
+                        profileImage = it.profileImage
+                    )
+                } else {
+                    it
+                }
+            }
+            redisCacheService.putToCache(cacheKey, updatedList)
+        }
     }
 }

--- a/src/main/kotlin/com/dotori/v2/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/RedisCacheConfig.kt
@@ -1,0 +1,31 @@
+package com.dotori.v2.global.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisCacheConfig {
+    @Bean
+    fun contentCacheManager(connectionFactory: RedisConnectionFactory, objectMapper: ObjectMapper): CacheManager {
+        val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer()))
+            .entryTtl(Duration.ofHours(6))
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(connectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/RedisCacheConfig.kt
@@ -1,31 +1,22 @@
 package com.dotori.v2.global.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.data.redis.cache.RedisCacheConfiguration
-import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
-import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
-import java.time.Duration
 
 @Configuration
 @EnableCaching
 class RedisCacheConfig {
     @Bean
-    fun contentCacheManager(connectionFactory: RedisConnectionFactory, objectMapper: ObjectMapper): CacheManager {
-        val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
-            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer()))
-            .entryTtl(Duration.ofHours(6))
-
-        return RedisCacheManager.RedisCacheManagerBuilder
-            .fromConnectionFactory(connectionFactory)
-            .cacheDefaults(redisCacheConfiguration)
-            .build()
+    fun redisTemplate(redisConnectionFactory: RedisConnectionFactory): RedisTemplate<String, Any> {
+        return RedisTemplate<String, Any>().apply {
+            setConnectionFactory(redisConnectionFactory)
+            keySerializer = StringRedisSerializer()
+            valueSerializer = GenericJackson2JsonRedisSerializer()
+        }
     }
 }

--- a/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
@@ -19,14 +19,14 @@ class RedisCacheService(
     }
 
     fun updateCacheFromProfile(memberId: Long, uploadFile: String?) {
-        updateCache(memberId) { it.copy(profileImage = uploadFile) }
+        updateMemberCache(memberId) { it.copy(profileImage = uploadFile) }
     }
 
     fun updateCacheFromSelfStudy(memberId: Long, selfStudyStatus: SelfStudyStatus) {
-        updateCache(memberId) { it.copy(selfStudyStatus = selfStudyStatus) }
+        updateMemberCache(memberId) { it.copy(selfStudyStatus = selfStudyStatus) }
     }
 
-    private fun updateCache(memberId: Long, update: (FindAllStudentResDto) -> FindAllStudentResDto) {
+    private fun updateMemberCache(memberId: Long,update: (FindAllStudentResDto) -> FindAllStudentResDto) {
         val cacheKey = "memberList"
         val cachedData = getFromCache(cacheKey) as? List<FindAllStudentResDto>
 

--- a/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
@@ -1,0 +1,68 @@
+package com.dotori.v2.global.config.redis.service
+
+import com.dotori.v2.domain.member.enums.SelfStudyStatus
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentResDto
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class RedisCacheService(
+    private val redisTemplate: RedisTemplate<String,Any>
+) {
+
+    fun getFromCache(key: String): Any? {
+        return redisTemplate.opsForValue().get(key)
+    }
+
+    fun putToCache(key: String,value: Any) {
+        redisTemplate.opsForValue().set(key,value)
+    }
+
+    fun updateCacheFromProfile(memberId: Long, uploadFile: String?) {
+        val cacheKey = "memberList"
+        val cachedData = getFromCache(cacheKey) as? List<FindAllStudentResDto>
+
+        if (cachedData != null) {
+            val updatedList = cachedData.map {
+                if (it.id == memberId) {
+                    FindAllStudentResDto(
+                        id = it.id,
+                        gender = it.gender,
+                        memberName = it.memberName,
+                        stuNum = it.stuNum,
+                        role = it.role,
+                        selfStudyStatus = it.selfStudyStatus,
+                        profileImage = uploadFile
+                    )
+                } else {
+                    it
+                }
+            }
+            putToCache(cacheKey,updatedList)
+        }
+    }
+
+    fun updateCacheFromSelfStudy(memberId: Long,selfStudyStatus: SelfStudyStatus) {
+        val cacheKey = "memberList"
+        val cachedData = getFromCache(cacheKey) as? List<FindAllStudentResDto>
+
+        if (cachedData != null) {
+            val updatedList = cachedData.map {
+                if (it.id == memberId) {
+                    FindAllStudentResDto(
+                        id = it.id,
+                        gender = it.gender,
+                        memberName = it.memberName,
+                        stuNum = it.stuNum,
+                        role = it.role,
+                        selfStudyStatus = selfStudyStatus,
+                        profileImage = it.profileImage
+                    )
+                } else {
+                    it
+                }
+            }
+            putToCache(cacheKey, updatedList)
+        }
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
@@ -19,45 +19,21 @@ class RedisCacheService(
     }
 
     fun updateCacheFromProfile(memberId: Long, uploadFile: String?) {
-        val cacheKey = "memberList"
-        val cachedData = getFromCache(cacheKey) as? List<FindAllStudentResDto>
-
-        if (cachedData != null) {
-            val updatedList = cachedData.map {
-                if (it.id == memberId) {
-                    FindAllStudentResDto(
-                        id = it.id,
-                        gender = it.gender,
-                        memberName = it.memberName,
-                        stuNum = it.stuNum,
-                        role = it.role,
-                        selfStudyStatus = it.selfStudyStatus,
-                        profileImage = uploadFile
-                    )
-                } else {
-                    it
-                }
-            }
-            putToCache(cacheKey,updatedList)
-        }
+        updateCache(memberId) { it.copy(profileImage = uploadFile) }
     }
 
-    fun updateCacheFromSelfStudy(memberId: Long,selfStudyStatus: SelfStudyStatus) {
+    fun updateCacheFromSelfStudy(memberId: Long, selfStudyStatus: SelfStudyStatus) {
+        updateCache(memberId) { it.copy(selfStudyStatus = selfStudyStatus) }
+    }
+
+    private fun updateCache(memberId: Long, update: (FindAllStudentResDto) -> FindAllStudentResDto) {
         val cacheKey = "memberList"
         val cachedData = getFromCache(cacheKey) as? List<FindAllStudentResDto>
 
         if (cachedData != null) {
             val updatedList = cachedData.map {
                 if (it.id == memberId) {
-                    FindAllStudentResDto(
-                        id = it.id,
-                        gender = it.gender,
-                        memberName = it.memberName,
-                        stuNum = it.stuNum,
-                        role = it.role,
-                        selfStudyStatus = selfStudyStatus,
-                        profileImage = it.profileImage
-                    )
+                    update(it)
                 } else {
                     it
                 }

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceSynchronicityTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceSynchronicityTest.kt
@@ -10,6 +10,7 @@ import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SaveSelfStudyUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -26,13 +27,15 @@ class ApplySelfStudyServiceSynchronicityTest  : BehaviorSpec({
     val selfStudyCheckUtil = mockk<SelfStudyCheckUtil>()
     val saveSelfStudyUtil = mockk<SaveSelfStudyUtil>()
     val validDayOfWeekAndHourUtil = mockk<ValidDayOfWeekAndHourUtil>()
+    val redisCacheService = mockk<RedisCacheService>()
 
     val service = ApplySelfStudyServiceImpl(
         userUtil,
         findSelfStudyCountUtil,
         selfStudyCheckUtil,
         saveSelfStudyUtil,
-        validDayOfWeekAndHourUtil
+        validDayOfWeekAndHourUtil,
+        redisCacheService
     )
 
     given("유저가 주어지고") {
@@ -56,7 +59,8 @@ class ApplySelfStudyServiceSynchronicityTest  : BehaviorSpec({
             findSelfStudyCountUtil,
             selfStudyCount,
             selfStudyCheckUtil,
-            saveSelfStudyUtil
+            saveSelfStudyUtil,
+            redisCacheService
         )
 
         `when`("서비스를 실행하면") {
@@ -94,11 +98,13 @@ private fun init(
     findSelfStudyCountUtil: FindSelfStudyCountUtil,
     selfStudyCount: SelfStudyCount,
     selfStudyCheckUtil: SelfStudyCheckUtil,
-    saveSelfStudyUtil: SaveSelfStudyUtil
+    saveSelfStudyUtil: SaveSelfStudyUtil,
+    redisCacheService: RedisCacheService
 ) {
     every { validDayOfWeekAndHourUtil.validateApply() } returns Unit
     every { userUtil.fetchCurrentUser() } returns testMember
     every { findSelfStudyCountUtil.findSelfStudyCount() } returns selfStudyCount
     every { selfStudyCheckUtil.isSelfStudyStatusCan(testMember) } returns Unit
     every { saveSelfStudyUtil.save(testMember) } returns Unit
+    every { redisCacheService.updateCacheFromSelfStudy(any(), any()) } returns Unit
 }

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceTest.kt
@@ -14,6 +14,7 @@ import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SaveSelfStudyUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -29,13 +30,15 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
     val selfStudyCheckUtil = mockk<SelfStudyCheckUtil>()
     val saveSelfStudyUtil = mockk<SaveSelfStudyUtil>()
     val validDayOfWeekAndHourUtil = mockk<ValidDayOfWeekAndHourUtil>()
+    val redisCacheService = mockk<RedisCacheService>()
 
     val service = ApplySelfStudyServiceImpl(
         userUtil,
         findSelfStudyCountUtil,
         selfStudyCheckUtil,
         saveSelfStudyUtil,
-        validDayOfWeekAndHourUtil
+        validDayOfWeekAndHourUtil,
+        redisCacheService
     )
     given("유저가 주어지고") {
         val testMember = Member(
@@ -49,7 +52,7 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
             profileImage = null
         )
         val selfStudyCount = SelfStudyCount(id = 1)
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil, redisCacheService)
         `when`("서비스를 실행하면") {
             service.execute()
             then("save가 실행되어야함") {
@@ -71,7 +74,7 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil, redisCacheService)
 
         every { validDayOfWeekAndHourUtil.validateApply() } throws NotSelfStudyApplyDayException()
         `when`("신청할 수 없는 요일일때") {
@@ -81,7 +84,7 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil, redisCacheService)
 
         every { validDayOfWeekAndHourUtil.validateApply() } throws NotSelfStudyApplyHourException()
         `when`("신청할 수 없는 시간알때") {
@@ -91,7 +94,7 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil, redisCacheService)
 
         every { selfStudyCheckUtil.isSelfStudyStatusCan(testMember) } throws AlreadyApplySelfStudyException()
         `when`("이미 신청한 유저일때") {
@@ -111,11 +114,13 @@ private fun init(
     findSelfStudyCountUtil: FindSelfStudyCountUtil,
     selfStudyCount: SelfStudyCount,
     selfStudyCheckUtil: SelfStudyCheckUtil,
-    saveSelfStudyUtil: SaveSelfStudyUtil
+    saveSelfStudyUtil: SaveSelfStudyUtil,
+    redisCacheService: RedisCacheService
 ) {
     every { validDayOfWeekAndHourUtil.validateApply() } returns Unit
     every { userUtil.fetchCurrentUser() } returns testMember
     every { findSelfStudyCountUtil.findSelfStudyCount() } returns selfStudyCount
     every { selfStudyCheckUtil.isSelfStudyStatusCan(testMember) } returns Unit
     every { saveSelfStudyUtil.save(testMember) } returns Unit
+    every { redisCacheService.updateCacheFromSelfStudy(any(), any()) } returns Unit
 }

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/CancelSelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/CancelSelfStudyServiceTest.kt
@@ -13,6 +13,7 @@ import com.dotori.v2.domain.selfstudy.service.impl.CancelSelfStudyServiceImpl
 import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -28,12 +29,14 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
     val validDayOfWeekAndHourUtil = mockk<ValidDayOfWeekAndHourUtil>()
     val selfStudyRepository = mockk<SelfStudyRepository>()
     val selfStudyCheckUtil = mockk<SelfStudyCheckUtil>()
+    val redisCacheService = mockk<RedisCacheService>()
     val serviceImpl = CancelSelfStudyServiceImpl(
         userUtil,
         validDayOfWeekAndHourUtil,
         findSelfStudyCountUtil,
         selfStudyRepository,
-        selfStudyCheckUtil
+        selfStudyCheckUtil,
+        redisCacheService
     )
     given("유저가 주어지고") {
         val testMember = Member(
@@ -47,7 +50,7 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
             profileImage = null
         )
         val selfStudyCount = SelfStudyCount(id = 1, count = 1)
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository, redisCacheService)
         `when`("서비스를 실행하면") {
             serviceImpl.execute()
             then("delete 쿼리가 날라가야함") {
@@ -69,7 +72,7 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository, redisCacheService)
 
         every { validDayOfWeekAndHourUtil.validateCancel() } throws NotSelfStudyCancelHourException()
         `when`("취소를 할 수 없는 시간일때") {
@@ -79,7 +82,7 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository, redisCacheService)
 
         every { selfStudyCheckUtil.isSelfStudyStatusApplied(testMember) } throws NotAppliedException()
         `when`("자습에 신청하지 않았을때") {
@@ -89,7 +92,7 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository, redisCacheService)
 
 
     }
@@ -102,11 +105,13 @@ private fun init(
     findSelfStudyCountUtil: FindSelfStudyCountUtil,
     selfStudyCount: SelfStudyCount,
     selfStudyCheckUtil: SelfStudyCheckUtil,
-    selfStudyRepository: SelfStudyRepository
+    selfStudyRepository: SelfStudyRepository,
+    redisCacheService: RedisCacheService
 ) {
     every { validDayOfWeekAndHourUtil.validateCancel() } returns Unit
     every { userUtil.fetchCurrentUser() } returns testMember
     every { findSelfStudyCountUtil.findSelfStudyCount() } returns selfStudyCount
     every { selfStudyCheckUtil.isSelfStudyStatusApplied(testMember) } returns Unit
     every { selfStudyRepository.deleteByMember(testMember) } returns Unit
+    every { redisCacheService.updateCacheFromSelfStudy(any(), any()) } returns Unit
 }


### PR DESCRIPTION
💡 개요

- 학생정보 어드민 API에 캐시 기능을 추가했습니다.

📃 작업내용

- 학생정보 리스트 조회 로직에 Look Aside 읽기 캐시 전략 적용 및 리스트 내 정보가 변경될 수 있는 API 관련 로직에 Write Througt 쓰기 전략을 적용했습니다.