### PR TITLE
기상음악 캐시

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/music/schedule/MusicSchedule.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/schedule/MusicSchedule.kt
@@ -1,7 +1,9 @@
 package com.dotori.v2.domain.music.schedule
 
 import com.dotori.v2.domain.music.domain.repository.MusicRepository
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -10,13 +12,18 @@ import java.time.LocalDate
 @Component
 @Transactional
 class MusicSchedule(
-    private val musicRepository: MusicRepository
+    private val musicRepository: MusicRepository,
+    private val redisTemplate: RedisTemplate<String, Any>
 ) {
     private val log = LoggerFactory.getLogger(this.javaClass.simpleName)
 
     @Scheduled(cron = "0 0 0 ? * MON-FRI")
     fun weekdayMusicStatusReset() {
         musicRepository.updateMusicStatusMemberByMember()
+        val keys = redisTemplate.keys("musicList:*")
+        if(keys.isNotEmpty()) {
+            redisTemplate.delete(keys)
+        }
         log.info("Student Music Status Updated At {}", LocalDate.now())
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/music/service/impl/ApplyMusicServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/service/impl/ApplyMusicServiceImpl.kt
@@ -10,6 +10,9 @@ import com.dotori.v2.domain.music.exception.MusicCantRequestDateException
 import com.dotori.v2.domain.music.presentation.data.dto.ApplyMusicDto
 import com.dotori.v2.domain.music.presentation.data.req.ApplyMusicReqDto
 import com.dotori.v2.domain.music.service.ApplyMusicService
+import com.dotori.v2.domain.student.presentation.data.req.ModifyStudentInfoRequest
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentResDto
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.youtube.service.YoutubeService
 import com.dotori.v2.global.thirdparty.youtube.data.res.YoutubeResDto
 import com.dotori.v2.global.util.UserUtil
@@ -23,8 +26,10 @@ class ApplyMusicServiceImpl(
     private val userUtil: UserUtil,
     private val musicRepository: MusicRepository,
     private val youtubeService: YoutubeService,
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val redisCacheService: RedisCacheService
 ) : ApplyMusicService {
+
     override fun execute(applyMusicReqDto: ApplyMusicReqDto, dayOfWeek: DayOfWeek): Music {
         validDayOfWeek(dayOfWeek)
 

--- a/src/main/kotlin/com/dotori/v2/domain/music/service/impl/FindMusicsServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/service/impl/FindMusicsServiceImpl.kt
@@ -5,20 +5,38 @@ import com.dotori.v2.domain.music.domain.repository.MusicRepository
 import com.dotori.v2.domain.music.presentation.data.res.MusicListResDto
 import com.dotori.v2.domain.music.presentation.data.res.MusicResDto
 import com.dotori.v2.domain.music.service.FindMusicsService
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true, rollbackFor = [Exception::class])
 class FindMusicsServiceImpl(
-    private val musicRepository: MusicRepository
+    private val musicRepository: MusicRepository,
+    private val redisCacheService: RedisCacheService
 ) : FindMusicsService {
+
+    val CACHE_KEY = "musicList"
+
     override fun execute(date: LocalDate): MusicListResDto {
-        return MusicListResDto(
+
+        val cachedData = redisCacheService.getFromCache(CACHE_KEY)
+        if(cachedData != null) {
+            return cachedData as MusicListResDto
+        }
+
+        val response = MusicListResDto(
             content = musicRepository.findAllByCreatedDate(date)
                 .map { toDto(it) }
         )
+
+        if(date.isEqual(LocalDate.now())) {
+            redisCacheService.putToCache(CACHE_KEY, response)
+        }
+
+        return response
     }
 
     private fun toDto(music: Music): MusicResDto =

--- a/src/main/kotlin/com/dotori/v2/domain/student/service/impl/FindAllMemberServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/student/service/impl/FindAllMemberServiceImpl.kt
@@ -15,10 +15,12 @@ class FindAllMemberServiceImpl(
     private val memberRepository: MemberRepository,
     private val redisCacheService: RedisCacheService
 ) : FindAllMemberService {
-    override fun execute(): List<FindAllStudentResDto> {
-        val cacheKey = "memberList"
 
-        val cachedData = redisCacheService.getFromCache(cacheKey)
+    val CACHE_KEY = "memberList"
+
+    override fun execute(): List<FindAllStudentResDto> {
+
+        val cachedData = redisCacheService.getFromCache(CACHE_KEY)
         if (cachedData != null) {
             return cachedData as List<FindAllStudentResDto>
         }
@@ -35,7 +37,7 @@ class FindAllMemberServiceImpl(
             )
         }
 
-        redisCacheService.putToCache(cacheKey, members)
+        redisCacheService.putToCache(CACHE_KEY, members)
 
         return members
     }

--- a/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
@@ -7,15 +7,15 @@ import org.springframework.stereotype.Service
 
 @Service
 class RedisCacheService(
-    private val redisTemplate: RedisTemplate<String,Any>
+    private val redisTemplate: RedisTemplate<String, Any>
 ) {
 
     fun getFromCache(key: String): Any? {
         return redisTemplate.opsForValue().get(key)
     }
 
-    fun putToCache(key: String,value: Any) {
-        redisTemplate.opsForValue().set(key,value)
+    fun putToCache(key: String, value: Any) {
+        redisTemplate.opsForValue().set(key, value)
     }
 
     fun updateCacheFromProfile(memberId: Long, uploadFile: String?) {

--- a/src/test/kotlin/com/dotori/v2/domain/music/service/ApplyMusicServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/music/service/ApplyMusicServiceTest.kt
@@ -11,6 +11,7 @@ import com.dotori.v2.domain.music.exception.MusicAlreadyException
 import com.dotori.v2.domain.music.exception.MusicCantRequestDateException
 import com.dotori.v2.domain.music.presentation.data.req.ApplyMusicReqDto
 import com.dotori.v2.domain.music.service.impl.ApplyMusicServiceImpl
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.youtube.data.res.YoutubeResDto
 import com.dotori.v2.global.thirdparty.youtube.exception.NotValidUrlException
 import com.dotori.v2.global.thirdparty.youtube.service.YoutubeService
@@ -30,7 +31,8 @@ class ApplyMusicServiceTest : BehaviorSpec({
     val musicRepository = mockk<MusicRepository>()
     val youtubeService = mockk<YoutubeService>()
     val memberRepository = mockk<MemberRepository>()
-    val applyMusicService = ApplyMusicServiceImpl(userUtil, musicRepository, youtubeService, memberRepository)
+    val redisCacheService = mockk<RedisCacheService>()
+    val applyMusicService = ApplyMusicServiceImpl(userUtil, musicRepository, youtubeService, memberRepository, redisCacheService)
 
     given("유저가 주어지고") {
         val testMember = Member(


### PR DESCRIPTION
💡 Description

### Feature

#### 음악 정보 캐시
기상음악 신청 api의 응닶값이 List형태의 리턴값이 아니라 List 필드를 가지고있는 클래스가 Response값이라 
MutableList로 변형하여 값을 add하고 새로운 Response를 만들어 캐시를 업데이트하게 구현했습니다.

#### 캐시 동기화
12시가 되면 원래 있던 캐시들을 다 걷어냅니다. (당일날 음악정보들만 캐싱함)


> \+ 추가로 캐시키같은건 전역으로 관리하거나 ENUM으로 관리하거나 하는게 좋아보이네요