### PR TITLE
이미지 업로드시 확장자 vadliation 추가

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/member/exception/NotAcceptImgExtensionException.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/exception/NotAcceptImgExtensionException.kt
@@ -1,0 +1,6 @@
+package com.dotori.v2.domain.member.exception
+
+import com.dotori.v2.global.error.ErrorCode
+import com.dotori.v2.global.error.exception.BasicException
+
+class NotAcceptImgExtensionException : BasicException(ErrorCode.MEMBER_PROFILE_IMG_NOT_ACCEPT_EXTENSION)

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
@@ -14,7 +14,7 @@ class ProfileImageService (
 ) {
     fun imageUpload(member: Member, multipartFiles: MultipartFile?, isUpdate: Boolean) {
 
-        validationExtension(multipartFiles)
+        validateExtension(multipartFiles)
 
         val uploadFileUrl: String? = s3Service.uploadSingleFile(multipartFiles)
 

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
@@ -1,0 +1,35 @@
+package com.dotori.v2.domain.member.service
+
+import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.exception.NotAcceptImgExtensionException
+import com.dotori.v2.global.config.redis.service.RedisCacheService
+import com.dotori.v2.global.thirdparty.aws.s3.S3Service
+import org.springframework.web.multipart.MultipartFile
+
+abstract class ProfileImageService {
+    fun imageUpload(member: Member,
+                    multipartFiles: MultipartFile?,
+                    s3Service: S3Service,
+                    redisCacheService: RedisCacheService,
+                    isUpdate: Boolean) {
+
+        validationExtension(multipartFiles)
+
+        val uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
+
+        if (isUpdate) s3Service.deleteFile(member.profileImage!!)
+
+        member.updateProfileImage(uploadFile)
+
+        redisCacheService.updateCacheFromProfile(member.id, uploadFile)
+    }
+
+    private fun validationExtension(multipartFiles: MultipartFile?) {
+        val acceptList = listOf("jpg", "jpeg", "png")
+        val splitFile = multipartFiles?.originalFilename.toString().split(".")
+        val extension = splitFile.last().lowercase()
+
+        if (acceptList.none { it == extension })
+            throw NotAcceptImgExtensionException()
+    }
+}

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
@@ -25,7 +25,7 @@ class ProfileImageService (
         redisCacheService.updateCacheFromProfile(member.id, uploadFileUrl)
     }
 
-    private fun validationExtension(multipartFiles: MultipartFile?) {
+    private fun validateExtension(multipartFiles: MultipartFile?) {
         val acceptList = listOf("jpg", "jpeg", "png")
         val splitFile = multipartFiles?.originalFilename.toString().split(".")
         val extension = splitFile.last().lowercase()

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
@@ -16,13 +16,13 @@ class ProfileImageService (
 
         validationExtension(multipartFiles)
 
-        val uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
+        val uploadFileUrl: String? = s3Service.uploadSingleFile(multipartFiles)
 
         if (isUpdate) s3Service.deleteFile(member.profileImage!!)
 
-        member.updateProfileImage(uploadFile)
+        member.updateProfileImage(uploadFileUrl)
 
-        redisCacheService.updateCacheFromProfile(member.id, uploadFile)
+        redisCacheService.updateCacheFromProfile(member.id, uploadFileUrl)
     }
 
     private fun validationExtension(multipartFiles: MultipartFile?) {

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
@@ -12,7 +12,7 @@ class ProfileImageService (
     private val s3Service: S3Service,
     private val redisCacheService: RedisCacheService
 ) {
-    fun imageUpload(member: Member, multipartFiles: MultipartFile?, isUpdate: Boolean) {
+    fun imageUpload(member: Member, multipartFiles: MultipartFile?, isUpdate: Boolean = false) {
 
         validateExtension(multipartFiles)
 

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/ProfileImageService.kt
@@ -4,14 +4,15 @@ import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.exception.NotAcceptImgExtensionException
 import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
+import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 
-abstract class ProfileImageService {
-    fun imageUpload(member: Member,
-                    multipartFiles: MultipartFile?,
-                    s3Service: S3Service,
-                    redisCacheService: RedisCacheService,
-                    isUpdate: Boolean) {
+@Service
+class ProfileImageService (
+    private val s3Service: S3Service,
+    private val redisCacheService: RedisCacheService
+) {
+    fun imageUpload(member: Member, multipartFiles: MultipartFile?, isUpdate: Boolean) {
 
         validationExtension(multipartFiles)
 

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -1,6 +1,8 @@
 package com.dotori.v2.domain.member.service.impl
 
+import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.exception.NotAcceptImgExtensionException
+import com.dotori.v2.domain.member.service.ProfileImageService
 import com.dotori.v2.domain.member.service.UpdateProfileImageService
 import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
@@ -15,21 +17,9 @@ class UpdateProfileImageServiceImpl(
     private val userUtil: UserUtil,
     private val s3Service: S3Service,
     private val redisCacheService: RedisCacheService
-): UpdateProfileImageService {
+): ProfileImageService(), UpdateProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
-
-        val acceptList = listOf("jpg", "jpeg", "png")
-        val splitFile = multipartFiles?.originalFilename.toString().split(".")
-        val extension = splitFile.last().lowercase()
-
-        if (acceptList.none { it == extension })
-            throw NotAcceptImgExtensionException()
-
-        val member = userUtil.fetchCurrentUser()
-        var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
-        s3Service.deleteFile(member.profileImage!!)
-        member.updateProfileImage(uploadFile)
-
-        redisCacheService.updateCacheFromProfile(member.id, uploadFile)
+        val member: Member = userUtil.fetchCurrentUser()
+        imageUpload(member, multipartFiles, s3Service, redisCacheService, true)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.dotori.v2.domain.member.service.impl
 
+import com.dotori.v2.domain.member.exception.NotAcceptImgExtensionException
 import com.dotori.v2.domain.member.service.UpdateProfileImageService
 import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
@@ -16,6 +17,14 @@ class UpdateProfileImageServiceImpl(
     private val redisCacheService: RedisCacheService
 ): UpdateProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
+
+        val acceptList = listOf("jpg", "jpeg", "png")
+        val splitFile = multipartFiles?.originalFilename.toString().split(".")
+        val extension = splitFile.last().lowercase()
+
+        if (acceptList.none { it == extension })
+            throw NotAcceptImgExtensionException()
+
         val member = userUtil.fetchCurrentUser()
         var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
         s3Service.deleteFile(member.profileImage!!)

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -16,6 +16,6 @@ class UpdateProfileImageServiceImpl(
 ): UpdateProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
-        profileImageService.imageUpload(member, multipartFiles, true)
+        profileImageService.imageUpload(member, multipartFiles, isUpdate = true)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -16,6 +16,6 @@ class UpdateProfileImageServiceImpl(
 ): UpdateProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
-        profileImageService.imageUpload(member, multipartFiles, isUpdate = true)
+        profileImageService.imageUpload(member = member, multipartFiles = multipartFiles, isUpdate = true)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -1,11 +1,8 @@
 package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.domain.entity.Member
-import com.dotori.v2.domain.member.exception.NotAcceptImgExtensionException
 import com.dotori.v2.domain.member.service.ProfileImageService
 import com.dotori.v2.domain.member.service.UpdateProfileImageService
-import com.dotori.v2.global.config.redis.service.RedisCacheService
-import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,11 +12,10 @@ import org.springframework.web.multipart.MultipartFile
 @Transactional(rollbackFor = [Exception::class])
 class UpdateProfileImageServiceImpl(
     private val userUtil: UserUtil,
-    private val s3Service: S3Service,
-    private val redisCacheService: RedisCacheService
-): ProfileImageService(), UpdateProfileImageService {
+    private val profileImageService: ProfileImageService
+): UpdateProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
-        imageUpload(member, multipartFiles, s3Service, redisCacheService, true)
+        profileImageService.imageUpload(member, multipartFiles, true)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -1,11 +1,8 @@
 package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.domain.entity.Member
-import com.dotori.v2.domain.member.exception.NotAcceptImgExtensionException
 import com.dotori.v2.domain.member.service.ProfileImageService
 import com.dotori.v2.domain.member.service.UploadProfileImageService
-import com.dotori.v2.global.config.redis.service.RedisCacheService
-import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,11 +12,10 @@ import org.springframework.web.multipart.MultipartFile
 @Transactional(rollbackFor = [Exception::class])
 class UploadProfileImageServiceImpl(
     private val userUtil: UserUtil,
-    private val s3Service: S3Service,
-    private val redisCacheService: RedisCacheService
-): ProfileImageService(), UploadProfileImageService {
+    private val profileImageService: ProfileImageService
+): UploadProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
-        imageUpload(member, multipartFiles, s3Service, redisCacheService,false);
+        profileImageService.imageUpload(member, multipartFiles, false)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -16,6 +16,6 @@ class UploadProfileImageServiceImpl(
 ): UploadProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
-        profileImageService.imageUpload(member, multipartFiles, false)
+        profileImageService.imageUpload(member, multipartFiles, isUpdate = false)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -16,6 +16,6 @@ class UploadProfileImageServiceImpl(
 ): UploadProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
-        profileImageService.imageUpload(member, multipartFiles, isUpdate = false)
+        profileImageService.imageUpload(member = member, multipartFiles = multipartFiles)
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.domain.entity.Member
+import com.dotori.v2.domain.member.exception.NotAcceptImgExtensionException
 import com.dotori.v2.domain.member.service.UploadProfileImageService
 import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
@@ -17,6 +18,14 @@ class UploadProfileImageServiceImpl(
     private val redisCacheService: RedisCacheService
 ): UploadProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
+
+        val acceptList = listOf("jpg", "jpeg", "png")
+        val splitFile = multipartFiles?.originalFilename.toString().split(".")
+        val extension = splitFile.last().lowercase()
+
+        if (acceptList.none { it == extension })
+            throw NotAcceptImgExtensionException()
+
         val member: Member = userUtil.fetchCurrentUser()
         var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
         member.updateProfileImage(uploadFile)

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -2,6 +2,7 @@ package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.exception.NotAcceptImgExtensionException
+import com.dotori.v2.domain.member.service.ProfileImageService
 import com.dotori.v2.domain.member.service.UploadProfileImageService
 import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
@@ -16,20 +17,9 @@ class UploadProfileImageServiceImpl(
     private val userUtil: UserUtil,
     private val s3Service: S3Service,
     private val redisCacheService: RedisCacheService
-): UploadProfileImageService {
+): ProfileImageService(), UploadProfileImageService {
     override fun execute(multipartFiles: MultipartFile?) {
-
-        val acceptList = listOf("jpg", "jpeg", "png")
-        val splitFile = multipartFiles?.originalFilename.toString().split(".")
-        val extension = splitFile.last().lowercase()
-
-        if (acceptList.none { it == extension })
-            throw NotAcceptImgExtensionException()
-
         val member: Member = userUtil.fetchCurrentUser()
-        var uploadFile: String? = s3Service.uploadSingleFile(multipartFiles)
-        member.updateProfileImage(uploadFile)
-
-        redisCacheService.updateCacheFromProfile(member.id, uploadFile)
+        imageUpload(member, multipartFiles, s3Service, redisCacheService,false);
     }
 }

--- a/src/main/kotlin/com/dotori/v2/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dotori/v2/global/error/ErrorCode.kt
@@ -42,6 +42,7 @@ enum class ErrorCode(
     MEMBER_EMAIL_HAS_NOT_AUTH_KEY(HttpStatus.NOT_FOUND.value(), "인증번호가 존재 하지 않습니다"),
     MEMBER_EMAIL_HAS_NOT_BEEN_CERTIFICATE(HttpStatus.ACCEPTED.value(), "이메일 인증이 되지않았습니다."),
     MEMBER_NOT_SAME(HttpStatus.UNAUTHORIZED.value(), "유저가 일치하지 않습니다."),
+    MEMBER_PROFILE_IMG_NOT_ACCEPT_EXTENSION(HttpStatus.BAD_REQUEST.value(), "지원하지 않는 프로필 사진 확장자 입니다."),
 
 
     // *** SELF STUDY ***


### PR DESCRIPTION
💡 개요

이미지 업로드시 서버단에서 확장자 검사를 하지않아 파일 업로드 공격이 가능합니다.
이미지 업로드 비즈니스 로직에서 파일 확장자 검사를 진행하는 로직을 추가하였습니다.

#356 

📃 작업내용

<img width="682" alt="스크린샷 2024-07-03 오후 5 29 57" src="https://github.com/Team-Ampersand/Dotori-server-V2/assets/131235625/6bee9297-1378-4bc1-bbd6-309b5da876b4">

- 프로필 이미지를 업로드하는 서비스 로직인 `UpdateProfileImageServiceImpl`, `UploadProfileImageServiceImpl`에 확장자 검사 로직을 추가하였습니다. c1a08ebe037b7d8c50a5f1a69ce2f728157efd22
- 허용하는 확장자는 임의로 `jpg`, `jpeg`, `png`로 제한 해두었습니다. 추가해야할 확장자가 있다면 수정하도록 하겠습니다.


🔀 변경사항

확장자 검사 로직을 추가하면서 중복되는 코드가 많이 발생하여 추상클래스를 도입해보았습니다. 해당 변경사항에 대해 이견이 있시면 말씀해주시면 걷어내도록 하겠습니다!

- 확장자 검사 로직을 추가하면서 `UpdateProfileImageServiceImpl`, `UploadProfileImageServiceImpl`에서 중복되는 부분이 많이 발생하였습니다. (파일 업데이트시 기존 파일을 제거하는 로직을 제외하고 동일한 로직으로 확인하였습니다.)
- 위의 두 클래스에서 `ProfileImageService`라는 추상클래스를 상속받도록 하여 `imageUpload` 메서드에서 중복되는 로직을 한번에 처리하도록 구현해보았습니다.
- `imageUpload` 메서드에서는 `isUpdate`라는 파라미터를 받아 기존 파일 삭제 여부를 받도록 구현하였습니다. ec06ac5a5a96f779bf2a89d4f08c4bc3f871fd76


