### PR TITLE
음악 데이터 초기화 스케쥴링

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -1,7 +1,7 @@
 package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.domain.entity.Member
-import com.dotori.v2.domain.member.service.ProfileImageService
+import com.dotori.v2.global.util.ProfileImageService
 import com.dotori.v2.domain.member.service.UpdateProfileImageService
 import com.dotori.v2.global.util.UserUtil
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UploadProfileImageServiceImpl.kt
@@ -1,7 +1,7 @@
 package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.domain.entity.Member
-import com.dotori.v2.domain.member.service.ProfileImageService
+import com.dotori.v2.global.util.ProfileImageService
 import com.dotori.v2.domain.member.service.UploadProfileImageService
 import com.dotori.v2.global.util.UserUtil
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/dotori/v2/domain/music/domain/repository/MusicRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/domain/repository/MusicRepository.kt
@@ -1,15 +1,12 @@
 package com.dotori.v2.domain.music.domain.repository
 
-import com.dotori.v2.domain.member.domain.entity.Member
-import com.dotori.v2.domain.member.enums.MusicStatus
 import com.dotori.v2.domain.music.domain.entity.Music
-import javax.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 interface MusicRepository : JpaRepository<Music, Long> {
     @Modifying
@@ -18,5 +15,7 @@ interface MusicRepository : JpaRepository<Music, Long> {
 
     @Query(value = "select * from music where created_date like :date%", nativeQuery = true)
     fun findAllByCreatedDate(@Param("date") date: LocalDate): List<Music>
+
+    fun deleteAllByCreatedDateBefore(date: LocalDateTime)
 
 }

--- a/src/main/kotlin/com/dotori/v2/domain/music/schedule/MusicSchedule.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/schedule/MusicSchedule.kt
@@ -22,8 +22,6 @@ class MusicSchedule(
     @Scheduled(cron = "0 0 0 ? * MON-FRI")
     fun weekdayMusicStatusReset() {
         musicRepository.updateMusicStatusMemberByMember()
-        redisCacheService.initCache("musicList:*")
-        log.info("init member music status")
     }
 
     @Scheduled(cron = "0 0 0 1 *")

--- a/src/main/kotlin/com/dotori/v2/domain/music/schedule/MusicSchedule.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/schedule/MusicSchedule.kt
@@ -8,22 +8,30 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @Component
 @Transactional
 class MusicSchedule(
     private val musicRepository: MusicRepository,
-    private val redisTemplate: RedisTemplate<String, Any>
+    private val redisCacheService: RedisCacheService
 ) {
     private val log = LoggerFactory.getLogger(this.javaClass.simpleName)
 
     @Scheduled(cron = "0 0 0 ? * MON-FRI")
     fun weekdayMusicStatusReset() {
         musicRepository.updateMusicStatusMemberByMember()
-        val keys = redisTemplate.keys("musicList:*")
-        if(keys.isNotEmpty()) {
-            redisTemplate.delete(keys)
-        }
-        log.info("Student Music Status Updated At {}", LocalDate.now())
+        redisCacheService.initCache("musicList:*")
+        log.info("init member music status")
     }
+
+    @Scheduled(cron = "0 0 0 1 *")
+    fun initMusic() {
+        val localDateTime = LocalDateTime.now().minus(2,ChronoUnit.MONTHS)
+        musicRepository.deleteAllByCreatedDateBefore(localDateTime)
+        redisCacheService.initCache("musicList:*")
+        log.info("delete music data schedule")
+    }
+
 }

--- a/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
@@ -4,6 +4,7 @@ import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentResDto
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class RedisCacheService(
@@ -24,6 +25,13 @@ class RedisCacheService(
 
     fun updateCacheFromSelfStudy(memberId: Long, selfStudyStatus: SelfStudyStatus) {
         updateMemberCache(memberId) { it.copy(selfStudyStatus = selfStudyStatus) }
+    }
+
+    fun initCache(pattern: String) {
+        val keys = redisTemplate.keys(pattern)
+        if(keys.isNotEmpty()) {
+            redisTemplate.delete(pattern)
+        }
     }
 
     private fun updateMemberCache(memberId: Long,update: (FindAllStudentResDto) -> FindAllStudentResDto) {

--- a/src/main/kotlin/com/dotori/v2/global/util/ProfileImageService.kt
+++ b/src/main/kotlin/com/dotori/v2/global/util/ProfileImageService.kt
@@ -1,4 +1,4 @@
-package com.dotori.v2.domain.member.service
+package com.dotori.v2.global.util
 
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.exception.NotAcceptImgExtensionException


### PR DESCRIPTION
💡 개요
음악 데이터를 매달 1일마다 두 달전 모든 데이터들이 삭제되는 스케쥴러입니다.

### 구현
음악 데이터를 삭제함에 따라서 캐시도 걷어야하기 때문에 RedisCacheService에 캐시를 invalid하는 로직을 분리했습니다.