### PR TITLE
update :: self-study time

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/properties/SelfStudyProperties.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/properties/SelfStudyProperties.kt
@@ -6,6 +6,6 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @ConfigurationProperties(prefix = "self-study")
 class SelfStudyProperties {
-    var allowedStartTime: String? = null
-    var allowedEndTime: String? = null
+    var allowedStartTime: String = "20:00"
+    var allowedEndTime: String = "20:59"
 }

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/properties/SelfStudyProperties.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/properties/SelfStudyProperties.kt
@@ -1,0 +1,10 @@
+package com.dotori.v2.domain.selfstudy.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "self-study")
+class SelfStudyProperties {
+    var allowedTime: String? = null
+}

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/properties/SelfStudyProperties.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/properties/SelfStudyProperties.kt
@@ -6,5 +6,6 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @ConfigurationProperties(prefix = "self-study")
 class SelfStudyProperties {
-    var allowedTime: String? = null
+    var allowedStartTime: String? = null
+    var allowedEndTime: String? = null
 }

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
@@ -7,6 +7,7 @@ import com.dotori.v2.domain.selfstudy.exception.NotSelfStudyCancelDayException
 import com.dotori.v2.domain.selfstudy.exception.NotSelfStudyCancelHourException
 import com.dotori.v2.global.error.ErrorCode
 import com.dotori.v2.global.error.exception.BasicException
+import org.springframework.core.env.Environment
 import org.springframework.stereotype.Component
 import java.time.DayOfWeek
 import java.time.LocalDateTime
@@ -14,38 +15,47 @@ import java.time.LocalTime
 
 @Component
 class ValidDayOfWeekAndHourUtil(
-    private val selfStudyProperties: SelfStudyProperties
+    private val selfStudyProperties: SelfStudyProperties,
+    private val environment: Environment
 ) {
 
     fun validateApply() {
         val currentTime = LocalDateTime.now()
         val dayOfWeek = currentTime.dayOfWeek
 
-        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
+        if (!isDevProfile() && (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)) {
             throw NotSelfStudyApplyDayException()
+        }
 
         val allowedStartTime = selfStudyProperties.allowedStartTime?.let { LocalTime.parse(it) }
             ?: throw BasicException(ErrorCode.UNKNOWN_ERROR)
         val allowedEndTime = selfStudyProperties.allowedEndTime?.let { LocalTime.parse(it) }
             ?: throw BasicException(ErrorCode.UNKNOWN_ERROR)
 
-        if (currentTime.toLocalTime().isBefore(allowedStartTime) || currentTime.toLocalTime().isAfter(allowedEndTime))
+        if (currentTime.toLocalTime().isBefore(allowedStartTime) || currentTime.toLocalTime().isAfter(allowedEndTime)) {
             throw NotSelfStudyApplyHourException()
+        }
     }
 
     fun validateCancel() {
         val currentTime = LocalDateTime.now()
         val dayOfWeek = currentTime.dayOfWeek
 
-        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
+        if (!isDevProfile() && (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)) {
             throw NotSelfStudyCancelDayException()
+        }
 
         val allowedStartTime = selfStudyProperties.allowedStartTime?.let { LocalTime.parse(it) }
             ?: throw BasicException(ErrorCode.UNKNOWN_ERROR)
         val allowedEndTime = selfStudyProperties.allowedEndTime?.let { LocalTime.parse(it) }
             ?: throw BasicException(ErrorCode.UNKNOWN_ERROR)
 
-        if (currentTime.toLocalTime().isBefore(allowedStartTime) || currentTime.toLocalTime().isAfter(allowedEndTime))
+        if (currentTime.toLocalTime().isBefore(allowedStartTime) || currentTime.toLocalTime().isAfter(allowedEndTime)) {
             throw NotSelfStudyCancelHourException()
+        }
+    }
+
+    private fun isDevProfile(): Boolean {
+        return environment.activeProfiles.contains("dev")
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
@@ -1,17 +1,23 @@
 package com.dotori.v2.domain.selfstudy.util
 
+import com.dotori.v2.domain.selfstudy.properties.SelfStudyProperties
 import com.dotori.v2.domain.selfstudy.exception.NotSelfStudyApplyDayException
 import com.dotori.v2.domain.selfstudy.exception.NotSelfStudyApplyHourException
 import com.dotori.v2.domain.selfstudy.exception.NotSelfStudyCancelDayException
 import com.dotori.v2.domain.selfstudy.exception.NotSelfStudyCancelHourException
+import com.dotori.v2.global.error.ErrorCode
+import com.dotori.v2.global.error.exception.BasicException
 import org.springframework.stereotype.Component
 import java.time.DayOfWeek
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Component
 class ValidDayOfWeekAndHourUtil(
+    private val selfStudyProperties: SelfStudyProperties,
     private val currentTime: LocalDateTime? = null
 ) {
+
      fun validateApply() {
          val currentTime = currentTime ?: LocalDateTime.now()
          val dayOfWeek = currentTime.dayOfWeek
@@ -20,8 +26,12 @@ class ValidDayOfWeekAndHourUtil(
          if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
             throw NotSelfStudyApplyDayException()
 
-         if (hour != 20)
-            throw NotSelfStudyApplyHourException()
+         val allowedTime = selfStudyProperties.allowedTime ?: throw BasicException(ErrorCode.BAD_REQUEST);
+         val allowedStartTime = LocalTime.parse(allowedTime.split("-")[0])
+         val allowedEndTime = LocalTime.parse(allowedTime.split("-")[1])
+
+         if (currentTime.toLocalTime().isBefore(allowedStartTime) || currentTime.toLocalTime().isAfter(allowedEndTime))
+             throw NotSelfStudyApplyHourException()
     }
 
     fun validateCancel() {
@@ -32,8 +42,11 @@ class ValidDayOfWeekAndHourUtil(
         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
             throw NotSelfStudyCancelDayException()
 
-        if (hour != 20)
+        val allowedTime = selfStudyProperties.allowedTime ?: throw BasicException(ErrorCode.BAD_REQUEST);
+        val allowedStartTime = LocalTime.parse(allowedTime.split("-")[0])
+        val allowedEndTime = LocalTime.parse(allowedTime.split("-")[1])
+
+        if (currentTime.toLocalTime().isBefore(allowedStartTime) || currentTime.toLocalTime().isAfter(allowedEndTime))
             throw NotSelfStudyCancelHourException()
     }
-
 }

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
@@ -21,7 +21,6 @@ class ValidDayOfWeekAndHourUtil(
      fun validateApply() {
          val currentTime = currentTime ?: LocalDateTime.now()
          val dayOfWeek = currentTime.dayOfWeek
-         val hour = currentTime.hour
 
          if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
             throw NotSelfStudyApplyDayException()
@@ -37,7 +36,6 @@ class ValidDayOfWeekAndHourUtil(
     fun validateCancel() {
         val currentTime = currentTime ?: LocalDateTime.now()
         val dayOfWeek = currentTime.dayOfWeek
-        val hour = currentTime.hour
 
         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
             throw NotSelfStudyCancelDayException()

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
@@ -14,12 +14,11 @@ import java.time.LocalTime
 
 @Component
 class ValidDayOfWeekAndHourUtil(
-    private val selfStudyProperties: SelfStudyProperties,
-    private val currentTime: LocalDateTime? = null
+    private val selfStudyProperties: SelfStudyProperties
 ) {
 
     fun validateApply() {
-        val currentTime = currentTime ?: LocalDateTime.now()
+        val currentTime = LocalDateTime.now()
         val dayOfWeek = currentTime.dayOfWeek
 
         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
@@ -35,7 +34,7 @@ class ValidDayOfWeekAndHourUtil(
     }
 
     fun validateCancel() {
-        val currentTime = currentTime ?: LocalDateTime.now()
+        val currentTime = LocalDateTime.now()
         val dayOfWeek = currentTime.dayOfWeek
 
         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
@@ -18,19 +18,20 @@ class ValidDayOfWeekAndHourUtil(
     private val currentTime: LocalDateTime? = null
 ) {
 
-     fun validateApply() {
-         val currentTime = currentTime ?: LocalDateTime.now()
-         val dayOfWeek = currentTime.dayOfWeek
+    fun validateApply() {
+        val currentTime = currentTime ?: LocalDateTime.now()
+        val dayOfWeek = currentTime.dayOfWeek
 
-         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
+        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
             throw NotSelfStudyApplyDayException()
 
-         val allowedTime = selfStudyProperties.allowedTime ?: throw BasicException(ErrorCode.BAD_REQUEST);
-         val allowedStartTime = LocalTime.parse(allowedTime.split("-")[0])
-         val allowedEndTime = LocalTime.parse(allowedTime.split("-")[1])
+        val allowedStartTime = selfStudyProperties.allowedStartTime?.let { LocalTime.parse(it) }
+            ?: throw BasicException(ErrorCode.UNKNOWN_ERROR)
+        val allowedEndTime = selfStudyProperties.allowedEndTime?.let { LocalTime.parse(it) }
+            ?: throw BasicException(ErrorCode.UNKNOWN_ERROR)
 
-         if (currentTime.toLocalTime().isBefore(allowedStartTime) || currentTime.toLocalTime().isAfter(allowedEndTime))
-             throw NotSelfStudyApplyHourException()
+        if (currentTime.toLocalTime().isBefore(allowedStartTime) || currentTime.toLocalTime().isAfter(allowedEndTime))
+            throw NotSelfStudyApplyHourException()
     }
 
     fun validateCancel() {
@@ -40,9 +41,10 @@ class ValidDayOfWeekAndHourUtil(
         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY)
             throw NotSelfStudyCancelDayException()
 
-        val allowedTime = selfStudyProperties.allowedTime ?: throw BasicException(ErrorCode.BAD_REQUEST);
-        val allowedStartTime = LocalTime.parse(allowedTime.split("-")[0])
-        val allowedEndTime = LocalTime.parse(allowedTime.split("-")[1])
+        val allowedStartTime = selfStudyProperties.allowedStartTime?.let { LocalTime.parse(it) }
+            ?: throw BasicException(ErrorCode.UNKNOWN_ERROR)
+        val allowedEndTime = selfStudyProperties.allowedEndTime?.let { LocalTime.parse(it) }
+            ?: throw BasicException(ErrorCode.UNKNOWN_ERROR)
 
         if (currentTime.toLocalTime().isBefore(allowedStartTime) || currentTime.toLocalTime().isAfter(allowedEndTime))
             throw NotSelfStudyCancelHourException()

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/util/ValidaDayOfWeekAndHourTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/util/ValidaDayOfWeekAndHourTest.kt
@@ -4,93 +4,156 @@ import com.dotori.v2.domain.selfstudy.exception.NotSelfStudyApplyDayException
 import com.dotori.v2.domain.selfstudy.exception.NotSelfStudyApplyHourException
 import com.dotori.v2.domain.selfstudy.exception.NotSelfStudyCancelDayException
 import com.dotori.v2.domain.selfstudy.exception.NotSelfStudyCancelHourException
+import com.dotori.v2.domain.selfstudy.properties.SelfStudyProperties
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
 import java.time.LocalDateTime
+import org.springframework.core.env.Environment
 
-class ValidaDayOfWeekAndHourTest : BehaviorSpec({
-    given("신청가능한 날짜 주어지고") {
-        val validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 27, 20, 0, 1)
-        `when`("신청가능한지 검증할때") {
-            then("아무 예외도 발생하지 않아야함") {
+class ValidDayOfWeekAndHourTest : BehaviorSpec({
+    mockkStatic(LocalDateTime::class)
+
+    // prod 프로파일에 대한 테스트 케이스
+    given("신청가능한 날짜가 주어지고 prod 프로파일") {
+        val validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 27, 20, 0, 1, "prod")
+        `when`("신청가능한지 검증할 때") {
+            then("아무 예외도 발생하지 않아야 함") {
                 validDayOfWeekAndHourUtil.validateApply() shouldBe Unit
             }
         }
-        `when`("신청취소가 가능한지 검증할때") {
-            then("아무 예외도 발생하지 않아야함") {
+        `when`("신청취소가 가능한지 검증할 때") {
+            then("아무 예외도 발생하지 않아야 함") {
                 validDayOfWeekAndHourUtil.validateCancel()
             }
         }
     }
-    given("시간이 오후 8시가 아닌 날짜가 주어지면") {
-        val validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 27, 19, 0, 0)
-        `when`("신청가능한지 검증할때") {
-            then("NotSelfStudyApplyHourException이 발생해야함") {
+    given("시간이 오후 8시가 아닌 날짜가 주어지면 prod 프로파일") {
+        val validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 27, 19, 0, 0, "prod")
+        `when`("신청가능한지 검증할 때") {
+            then("NotSelfStudyApplyHourException이 발생해야 함") {
                 shouldThrow<NotSelfStudyApplyHourException> {
                     validDayOfWeekAndHourUtil.validateApply()
                 }
             }
         }
-        `when`("신청취소가 가능한지 검증할때") {
-            then("NotSelfStudyCancelHourException이 발생해야함") {
+        `when`("신청취소가 가능한지 검증할 때") {
+            then("NotSelfStudyCancelHourException이 발생해야 함") {
                 shouldThrow<NotSelfStudyCancelHourException> {
                     validDayOfWeekAndHourUtil.validateCancel()
                 }
             }
         }
     }
-    given("날짜가 금요일이나 주말인 날짜가 주어지면") {
-        var validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 28, 20, 0, 0)
-        `when`("금요일에 신청가능한지 검증할때") {
-            then("NotSelfStudyApplyHourException이 발생해야함") {
+    given("날짜가 금요일이나 주말인 날짜가 주어지면 prod 프로파일") {
+        var validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 28, 20, 0, 0, "prod")
+        `when`("금요일에 신청가능한지 검증할 때") {
+            then("NotSelfStudyApplyDayException이 발생해야 함") {
                 shouldThrow<NotSelfStudyApplyDayException> {
                     validDayOfWeekAndHourUtil.validateApply()
                 }
             }
         }
-        `when`("금요일에 신청취소가 가능한지 검증할때") {
-            then("NotSelfStudyCancelDayException이 발생해야함") {
+        `when`("금요일에 신청취소가 가능한지 검증할 때") {
+            then("NotSelfStudyCancelDayException이 발생해야 함") {
                 shouldThrow<NotSelfStudyCancelDayException> {
                     validDayOfWeekAndHourUtil.validateCancel()
                 }
             }
         }
-        validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 29, 20, 0, 0)
-        `when`("토요일에 신청가능한지 검증할때") {
-            then("NotSelfStudyApplyHourException이 발생해야함") {
+        validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 29, 20, 0, 0, "prod")
+        `when`("토요일에 신청가능한지 검증할 때") {
+            then("NotSelfStudyApplyDayException이 발생해야 함") {
                 shouldThrow<NotSelfStudyApplyDayException> {
                     validDayOfWeekAndHourUtil.validateApply()
                 }
             }
         }
-        `when`("토요일에 신청취소가 가능한지 검증할때") {
-            then("NotSelfStudyCancelDayException이 발생해야함") {
+        `when`("토요일에 신청취소가 가능한지 검증할 때") {
+            then("NotSelfStudyCancelDayException이 발생해야 함") {
                 shouldThrow<NotSelfStudyCancelDayException> {
                     validDayOfWeekAndHourUtil.validateCancel()
                 }
             }
         }
-        /*
-        validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 30, 20, 0, 0)
-        `when`("일요일에 신청가능한지 검증할때") {
-            then("NotSelfStudyApplyHourException이 발생해야함") {
-                shouldThrow<NotSelfStudyApplyDayException> {
+    }
+
+    // dev 프로파일에 대한 테스트 케이스
+    given("신청가능한 날짜가 주어지고 dev 프로파일") {
+        val validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 27, 20, 0, 1, "dev")
+        `when`("신청가능한지 검증할 때") {
+            then("아무 예외도 발생하지 않아야 함") {
+                validDayOfWeekAndHourUtil.validateApply() shouldBe Unit
+            }
+        }
+        `when`("신청취소가 가능한지 검증할 때") {
+            then("아무 예외도 발생하지 않아야 함") {
+                validDayOfWeekAndHourUtil.validateCancel()
+            }
+        }
+    }
+    given("시간이 오후 8시가 아닌 날짜가 주어지면 dev 프로파일") {
+        val validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 27, 19, 0, 0, "dev")
+        `when`("신청가능한지 검증할 때") {
+            then("NotSelfStudyApplyHourException이 발생해야 함") {
+                shouldThrow<NotSelfStudyApplyHourException> {
                     validDayOfWeekAndHourUtil.validateApply()
                 }
             }
         }
-        `when`("일요일에 신청취소가 가능한지 검증할때") {
-            then("NotSelfStudyCancelDayException이 발생해야함") {
-                shouldThrow<NotSelfStudyCancelDayException> {
+        `when`("신청취소가 가능한지 검증할 때") {
+            then("NotSelfStudyCancelHourException이 발생해야 함") {
+                shouldThrow<NotSelfStudyCancelHourException> {
                     validDayOfWeekAndHourUtil.validateCancel()
                 }
             }
-        }*/
+        }
+    }
+    given("날짜가 금요일이나 주말인 날짜가 주어지면 dev 프로파일") {
+        var validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 28, 20, 0, 0, "dev")
+        `when`("금요일에 신청가능한지 검증할 때") {
+            then("아무 예외도 발생하지 않아야 함") {
+                validDayOfWeekAndHourUtil.validateApply() shouldBe Unit
+            }
+        }
+        `when`("금요일에 신청취소가 가능한지 검증할 때") {
+            then("아무 예외도 발생하지 않아야 함") {
+                validDayOfWeekAndHourUtil.validateCancel()
+            }
+        }
+        validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 29, 20, 0, 0, "dev")
+        `when`("토요일에 신청가능한지 검증할 때") {
+            then("아무 예외도 발생하지 않아야 함") {
+                validDayOfWeekAndHourUtil.validateApply() shouldBe Unit
+            }
+        }
+        `when`("토요일에 신청취소가 가능한지 검증할 때") {
+            then("아무 예외도 발생하지 않아야 함") {
+                validDayOfWeekAndHourUtil.validateCancel()
+            }
+        }
     }
 })
 
-private fun validDayOfWeekAndHourUtil(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int): ValidDayOfWeekAndHourUtil {
+private fun validDayOfWeekAndHourUtil(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, profile: String): ValidDayOfWeekAndHourUtil {
     val testDate = LocalDateTime.of(year, month, day, hour, minute, second)
-    return ValidDayOfWeekAndHourUtil(testDate)
+    val selfStudyProperties = mockk<SelfStudyProperties>()
+    val environment = mockk<Environment>()
+
+    every { environment.activeProfiles } returns arrayOf(profile)
+
+    if (profile == "dev") {
+        every { selfStudyProperties.allowedStartTime } returns "00:00"
+        every { selfStudyProperties.allowedEndTime } returns "23:59"
+    } else if (profile == "prod") {
+        every { selfStudyProperties.allowedStartTime } returns "20:00"
+        every { selfStudyProperties.allowedEndTime } returns "20:59"
+    }
+
+    every { LocalDateTime.now() } returns testDate
+
+    return ValidDayOfWeekAndHourUtil(selfStudyProperties, environment)
 }

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/util/ValidaDayOfWeekAndHourTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/util/ValidaDayOfWeekAndHourTest.kt
@@ -97,18 +97,14 @@ class ValidDayOfWeekAndHourTest : BehaviorSpec({
     }
     given("시간이 오후 8시가 아닌 날짜가 주어지면 dev 프로파일") {
         val validDayOfWeekAndHourUtil = validDayOfWeekAndHourUtil(2023, 4, 27, 19, 0, 0, "dev")
-        `when`("신청가능한지 검증할 때") {
-            then("NotSelfStudyApplyHourException이 발생해야 함") {
-                shouldThrow<NotSelfStudyApplyHourException> {
-                    validDayOfWeekAndHourUtil.validateApply()
-                }
+        `when`("신청가능한지 검증할 때"){
+            then("아무 예외도 발생하지 않아야 함") {
+                validDayOfWeekAndHourUtil.validateApply() shouldBe Unit
             }
         }
         `when`("신청취소가 가능한지 검증할 때") {
-            then("NotSelfStudyCancelHourException이 발생해야 함") {
-                shouldThrow<NotSelfStudyCancelHourException> {
-                    validDayOfWeekAndHourUtil.validateCancel()
-                }
+            then("아무 예외도 발생하지 않아야 함") {
+                validDayOfWeekAndHourUtil.validateCancel()
             }
         }
     }


### PR DESCRIPTION
💡 개요
profile이 dev일 때 자습신청이 "00:00-23:59"시에 모두 가능하도록 변경했습니다.

📃 작업내용
`ValidDayOfWeekAndHourUtil` 에서 selfStudyProperties값에 따라 자습신청을 다르게 제한하도록 작업하였습니다

🔀 변경사항
`application-dev.yml`, `application-prod.yml`에 self-study allowedTime 설정을 추가하였습니다