### PR TITLE
Hotfix/selfstudy info 500에러 해결

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/GetSelfStudyInfoServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/GetSelfStudyInfoServiceImpl.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-@Transactional(rollbackFor = [Exception::class])
+@Transactional
 class GetSelfStudyInfoServiceImpl(
     private val selfStudyCountRepository: SelfStudyCountRepository,
     private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil,

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/GetSelfStudyInfoServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/GetSelfStudyInfoServiceImpl.kt
@@ -1,14 +1,11 @@
 package com.dotori.v2.domain.selfstudy.service.impl
 
-import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.selfstudy.domain.entity.SelfStudyCount
 import com.dotori.v2.domain.selfstudy.domain.repository.SelfStudyCountRepository
-import com.dotori.v2.domain.selfstudy.exception.SelfStudyOverException
 import com.dotori.v2.domain.selfstudy.presentation.dto.res.SelfStudyInfoResDto
 import com.dotori.v2.domain.selfstudy.service.GetSelfStudyInfoService
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
-import com.dotori.v2.global.error.exception.BasicException
 import com.dotori.v2.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -39,11 +36,7 @@ class GetSelfStudyInfoServiceImpl(
     }
 
     private fun validSelfStudyApplyCant(selfStudyCount: SelfStudyCount): Boolean {
-        try {
-            validDayOfWeekAndHourUtil.validateApply()
-            if (selfStudyCount.count >= selfStudyCount.limit)
-                throw SelfStudyOverException()
-        } catch (ex: BasicException) {
+        if (!validDayOfWeekAndHourUtil.isApplyValid() || selfStudyCount.count >= selfStudyCount.limit) {
             return true
         }
         return false

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/GetSelfStudyInfoServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/GetSelfStudyInfoServiceImpl.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-@Transactional(readOnly = true, rollbackFor = [Exception::class])
+@Transactional(rollbackFor = [Exception::class])
 class GetSelfStudyInfoServiceImpl(
     private val selfStudyCountRepository: SelfStudyCountRepository,
     private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil,

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/util/ValidDayOfWeekAndHourUtil.kt
@@ -58,4 +58,12 @@ class ValidDayOfWeekAndHourUtil(
     private fun isDevProfile(): Boolean {
         return environment.activeProfiles.contains("dev")
     }
+    fun isApplyValid(): Boolean {
+        return try {
+            validateApply()
+            true
+        } catch (ex: BasicException) {
+            false
+        }
+    }
 }

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/GetSelfStudyInfoServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/GetSelfStudyInfoServiceTest.kt
@@ -21,7 +21,7 @@ class GetSelfStudyInfoServiceTest : BehaviorSpec({
     val userUtil = mockk<UserUtil>()
 
     val service = GetSelfStudyInfoServiceImpl(selfStudyCountRepository, validDayOfWeekAndHourUtil, userUtil)
-    given("유저가 주어지고"){
+    given("유저가 주어지고") {
         val testMember = Member(
             memberName = "test",
             stuNum = "2116",
@@ -35,13 +35,13 @@ class GetSelfStudyInfoServiceTest : BehaviorSpec({
         every { userUtil.fetchCurrentUser() } returns testMember
         val selfStudyCount = SelfStudyCount(id = 1)
         every { selfStudyCountRepository.findSelfStudyCountById(1) } returns selfStudyCount
-        every { validDayOfWeekAndHourUtil.validateApply() } returns Unit
+        every { validDayOfWeekAndHourUtil.isApplyValid() } returns true
         selfStudyCount.addCount()
         selfStudyCount.addCount()
-        `when`("서비스를 실행하면"){
+        `when`("서비스를 실행하면") {
             val result = service.execute()
-            then("결괴값이 유저의 정보와 2가 반환되어야함"){
-                result shouldBe SelfStudyInfoResDto(selfStudyStatus = testMember.selfStudyStatus, limit = 50, count = selfStudyCount.count)
+            then("결과값이 유저의 정보와 2가 반환되어야 함") {
+                result shouldBe SelfStudyInfoResDto(selfStudyStatus = testMember.selfStudyStatus,limit = 50, count = selfStudyCount.count)
             }
         }
     }


### PR DESCRIPTION
💡 개요
자습신청 info api 에서 500이 반환되는 에러 해결

📃 작업내용
GetSelfStudyInfoServiceImpl의 `@Transactional` readOnly 설정을 해제하였습니다