### PR TITLE
Music 좋아요, 좋아요 취소 시 현재 좋아요 수 반환 안됨

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/music/presentation/data/res/MusicLikeCountResDto.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/presentation/data/res/MusicLikeCountResDto.kt
@@ -1,5 +1,5 @@
 package com.dotori.v2.domain.music.presentation.data.res
 
 data class MusicLikeCountResDto(
-    private val likeCount: Int
+    val likeCount: Int
 )


### PR DESCRIPTION
💡 개요
dto 필드에 private 접근제어자 때문에 {} 만 반환되고 값은 반환되지 않고 있어서 접근제어자 삭제 했습니다.

📃 작업내용
- dto 필드에 private 삭제
