### PR TITLE
회원가입/탈퇴, 유저 프로필 설정, 자습 관련 코드에 캐시 관련 기능 추가

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignUpServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/auth/service/impl/SignUpServiceImpl.kt
@@ -7,6 +7,8 @@ import com.dotori.v2.domain.email.exception.EmailAuthNotFoundException
 import com.dotori.v2.domain.email.exception.EmailNotBeenException
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.exception.MemberAlreadyException
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentListResDto
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,7 +19,11 @@ class SignUpServiceImpl(
     private val emailCertificateRepository: EmailCertificateRepository,
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder,
+    private val redisCacheService: RedisCacheService
 ): SignUpService {
+
+    private val CACHE_KEY = "memberList"
+
     override fun execute(signUpReqDto: SignUpReqDto) {
         val emailCertificate = emailCertificateRepository.findByEmail(signUpReqDto.email)
             ?: throw EmailAuthNotFoundException()
@@ -34,5 +40,15 @@ class SignUpServiceImpl(
         val member = signUpReqDto.toEntity(encodedPassword)
 
         memberRepository.save(member)
+        initCache()
+    }
+
+    private fun initCache() {
+        val cachedData =
+            redisCacheService.getFromCache(CACHE_KEY) as? FindAllStudentListResDto
+
+        if (cachedData != null) {
+            redisCacheService.deleteFromCache(CACHE_KEY)
+        }
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/DeleteProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/DeleteProfileImageServiceImpl.kt
@@ -1,6 +1,8 @@
 package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.service.DeleteProfileImageService
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentListResDto
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
 import org.springframework.stereotype.Service
@@ -10,13 +12,25 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(rollbackFor = [Exception::class])
 class DeleteProfileImageServiceImpl(
     private val userUtil: UserUtil,
-    private val s3Service: S3Service
+    private val s3Service: S3Service,
+    private val redisCacheService: RedisCacheService
 ) : DeleteProfileImageService {
+
+    private val CACHE_KEY = "memberList"
 
     override fun execute() {
         val member = userUtil.fetchCurrentUser()
         s3Service.deleteFile(member.profileImage!!)
         member.updateProfileImage(null)
+        initCache()
     }
 
+    private fun initCache() {
+        val cachedData =
+            redisCacheService.getFromCache(CACHE_KEY) as? FindAllStudentListResDto
+
+        if (cachedData != null) {
+            redisCacheService.deleteFromCache(CACHE_KEY)
+        }
+    }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/UpdateProfileImageServiceImpl.kt
@@ -3,6 +3,8 @@ package com.dotori.v2.domain.member.service.impl
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.global.util.ProfileImageService
 import com.dotori.v2.domain.member.service.UpdateProfileImageService
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentListResDto
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,10 +14,24 @@ import org.springframework.web.multipart.MultipartFile
 @Transactional(rollbackFor = [Exception::class])
 class UpdateProfileImageServiceImpl(
     private val userUtil: UserUtil,
-    private val profileImageService: ProfileImageService
+    private val profileImageService: ProfileImageService,
+    private val redisCacheService: RedisCacheService
 ): UpdateProfileImageService {
+
+    private val CACHE_KEY = "memberList"
+
     override fun execute(multipartFiles: MultipartFile?) {
         val member: Member = userUtil.fetchCurrentUser()
         profileImageService.imageUpload(member = member, multipartFiles = multipartFiles)
+        initCache()
+    }
+
+    private fun initCache() {
+        val cachedData =
+            redisCacheService.getFromCache(CACHE_KEY) as? FindAllStudentListResDto
+
+        if (cachedData != null) {
+            redisCacheService.deleteFromCache(CACHE_KEY)
+        }
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/member/service/impl/WithdrawalServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/member/service/impl/WithdrawalServiceImpl.kt
@@ -2,6 +2,8 @@ package com.dotori.v2.domain.member.service.impl
 
 import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.service.WithdrawalService
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentListResDto
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import com.dotori.v2.global.util.UserUtil
 import org.springframework.stereotype.Service
@@ -13,10 +15,24 @@ class WithdrawalServiceImpl(
     private val memberRepository: MemberRepository,
     private val s3Service: S3Service,
     private val userUtil: UserUtil,
+    private val redisCacheService: RedisCacheService
 ) : WithdrawalService {
+
+    private val CACHE_KEY = "memberList"
+
     override fun execute() {
         val currentUser = userUtil.fetchCurrentUser()
         currentUser.profileImage?.let { s3Service.deleteFile(it) }
         memberRepository.delete(currentUser)
+        initCache()
+    }
+
+    private fun initCache() {
+        val cachedData =
+            redisCacheService.getFromCache(CACHE_KEY) as? FindAllStudentListResDto
+
+        if (cachedData != null) {
+            redisCacheService.deleteFromCache(CACHE_KEY)
+        }
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/ApplySelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/ApplySelfStudyServiceImpl.kt
@@ -7,6 +7,8 @@ import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SaveSelfStudyUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentListResDto
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
 import com.dotori.v2.indicator.IndicatorTarget
 import org.springframework.stereotype.Service
@@ -20,8 +22,11 @@ class ApplySelfStudyServiceImpl(
     private val findSelfStudyCountUtil: FindSelfStudyCountUtil,
     private val selfStudyCheckUtil: SelfStudyCheckUtil,
     private val saveSelfStudyUtil: SaveSelfStudyUtil,
-    private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil
+    private val validDayOfWeekAndHourUtil: ValidDayOfWeekAndHourUtil,
+    private val redisCacheService: RedisCacheService
 ) : ApplySelfStudyService{
+
+    private val CACHE_KEY = "memberList"
 
     @IndicatorTarget
     override fun execute() {
@@ -38,5 +43,15 @@ class ApplySelfStudyServiceImpl(
         member.updateSelfStudyStatus(SelfStudyStatus.APPLIED)
         selfStudyCount.addCount()
         saveSelfStudyUtil.save(member)
+        initCache()
+    }
+
+    private fun initCache() {
+        val cachedData =
+            redisCacheService.getFromCache(CACHE_KEY) as? FindAllStudentListResDto
+
+        if (cachedData != null) {
+            redisCacheService.deleteFromCache(CACHE_KEY)
+        }
     }
 }

--- a/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/CancelBanSelfStudyServiceImpl.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/selfstudy/service/impl/CancelBanSelfStudyServiceImpl.kt
@@ -5,6 +5,8 @@ import com.dotori.v2.domain.member.domain.repository.MemberRepository
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.selfstudy.service.CancelBanSelfStudyService
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentListResDto
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,12 +15,16 @@ import java.time.LocalDateTime
 @Service
 @Transactional(rollbackFor = [Exception::class])
 class CancelBanSelfStudyServiceImpl(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val redisCacheService: RedisCacheService
 ) : CancelBanSelfStudyService{
+
+    private val CACHE_KEY = "memberList"
+
     override fun execute(id: Long) {
         val member = memberRepository.findByIdOrNull(id) ?: throw MemberNotFoundException()
         updateSelfStudyAndExpiredDate(member, SelfStudyStatus.CAN, null)
-
+        initCache()
     }
 
     private fun updateSelfStudyAndExpiredDate(
@@ -28,5 +34,14 @@ class CancelBanSelfStudyServiceImpl(
     ) {
         findMember.updateSelfStudyStatus(selfStudyStatus)
         findMember.updateSelfStudyExpiredDate(localDateTime)
+    }
+
+    private fun initCache() {
+        val cachedData =
+            redisCacheService.getFromCache(CACHE_KEY) as? FindAllStudentListResDto
+
+        if (cachedData != null) {
+            redisCacheService.deleteFromCache(CACHE_KEY)
+        }
     }
 }

--- a/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/redis/service/RedisCacheService.kt
@@ -1,9 +1,8 @@
 package com.dotori.v2.global.config.redis.service
 
-import com.dotori.v2.domain.member.enums.SelfStudyStatus
-import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentResDto
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
 
 @Service
 class RedisCacheService(
@@ -16,6 +15,9 @@ class RedisCacheService(
 
     fun putToCache(key: String, value: Any) {
         redisTemplate.opsForValue().set(key, value)
+        if (key == "memberList") {
+            redisTemplate.expire(key, 1, TimeUnit.HOURS)
+        }
     }
 
     fun deleteFromCache(key: String) {
@@ -30,34 +32,10 @@ class RedisCacheService(
         return redisTemplate.opsForValue().get("musicList:$date")
     }
 
-    fun updateCacheFromProfile(memberId: Long, uploadFile: String?) {
-        updateMemberCache(memberId) { it.copy(profileImage = uploadFile) }
-    }
-
-    fun updateCacheFromSelfStudy(memberId: Long, selfStudyStatus: SelfStudyStatus) {
-        updateMemberCache(memberId) { it.copy(selfStudyStatus = selfStudyStatus) }
-    }
-
     fun initCache(pattern: String) {
         val keys = redisTemplate.keys(pattern)
         if(keys.isNotEmpty()) {
             redisTemplate.delete(pattern)
-        }
-    }
-
-    private fun updateMemberCache(memberId: Long, update: (FindAllStudentResDto) -> FindAllStudentResDto) {
-        val cacheKey = "memberList"
-        val cachedData = getFromCache(cacheKey) as? List<FindAllStudentResDto>
-
-        if (cachedData != null) {
-            val updatedList = cachedData.map {
-                if (it.id == memberId) {
-                    update(it)
-                } else {
-                    it
-                }
-            }
-            putToCache(cacheKey, updatedList)
         }
     }
 }

--- a/src/main/kotlin/com/dotori/v2/global/util/ProfileImageService.kt
+++ b/src/main/kotlin/com/dotori/v2/global/util/ProfileImageService.kt
@@ -2,15 +2,13 @@ package com.dotori.v2.global.util
 
 import com.dotori.v2.domain.member.domain.entity.Member
 import com.dotori.v2.domain.member.exception.NotAcceptImgExtensionException
-import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.thirdparty.aws.s3.S3Service
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 
 @Service
 class ProfileImageService (
-    private val s3Service: S3Service,
-    private val redisCacheService: RedisCacheService
+    private val s3Service: S3Service
 ) {
 
     fun imageUpload(member: Member, multipartFiles: MultipartFile?) {
@@ -23,8 +21,6 @@ class ProfileImageService (
         }
 
         member.updateProfileImage(uploadFileUrl)
-
-        redisCacheService.updateCacheFromProfile(member.id, uploadFileUrl)
     }
 
     private fun validateExtension(multipartFiles: MultipartFile?) {

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceSynchronicityTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceSynchronicityTest.kt
@@ -10,6 +10,7 @@ import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SaveSelfStudyUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -26,13 +27,15 @@ class ApplySelfStudyServiceSynchronicityTest  : BehaviorSpec({
     val selfStudyCheckUtil = mockk<SelfStudyCheckUtil>()
     val saveSelfStudyUtil = mockk<SaveSelfStudyUtil>()
     val validDayOfWeekAndHourUtil = mockk<ValidDayOfWeekAndHourUtil>()
+    val redisCacheService = mockk<RedisCacheService>()
 
     val service = ApplySelfStudyServiceImpl(
         userUtil,
         findSelfStudyCountUtil,
         selfStudyCheckUtil,
         saveSelfStudyUtil,
-        validDayOfWeekAndHourUtil
+        validDayOfWeekAndHourUtil,
+        redisCacheService
     )
 
     given("유저가 주어지고") {
@@ -56,7 +59,7 @@ class ApplySelfStudyServiceSynchronicityTest  : BehaviorSpec({
             findSelfStudyCountUtil,
             selfStudyCount,
             selfStudyCheckUtil,
-            saveSelfStudyUtil
+            saveSelfStudyUtil,
         )
 
         `when`("서비스를 실행하면") {
@@ -94,7 +97,7 @@ private fun init(
     findSelfStudyCountUtil: FindSelfStudyCountUtil,
     selfStudyCount: SelfStudyCount,
     selfStudyCheckUtil: SelfStudyCheckUtil,
-    saveSelfStudyUtil: SaveSelfStudyUtil
+    saveSelfStudyUtil: SaveSelfStudyUtil,
 ) {
     every { validDayOfWeekAndHourUtil.validateApply() } returns Unit
     every { userUtil.fetchCurrentUser() } returns testMember

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceTest.kt
@@ -14,6 +14,7 @@ import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SaveSelfStudyUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -29,13 +30,15 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
     val selfStudyCheckUtil = mockk<SelfStudyCheckUtil>()
     val saveSelfStudyUtil = mockk<SaveSelfStudyUtil>()
     val validDayOfWeekAndHourUtil = mockk<ValidDayOfWeekAndHourUtil>()
+    val redisCacheService = mockk<RedisCacheService>()
 
     val service = ApplySelfStudyServiceImpl(
         userUtil,
         findSelfStudyCountUtil,
         selfStudyCheckUtil,
         saveSelfStudyUtil,
-        validDayOfWeekAndHourUtil
+        validDayOfWeekAndHourUtil,
+        redisCacheService
     )
     given("유저가 주어지고") {
         val testMember = Member(

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/ApplySelfStudyServiceTest.kt
@@ -14,6 +14,7 @@ import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SaveSelfStudyUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.domain.student.presentation.data.res.FindAllStudentListResDto
 import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
 import io.kotest.assertions.throwables.shouldThrow
@@ -52,7 +53,8 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
             profileImage = null
         )
         val selfStudyCount = SelfStudyCount(id = 1)
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil)
+
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil, redisCacheService)
         `when`("서비스를 실행하면") {
             service.execute()
             then("save가 실행되어야함") {
@@ -74,7 +76,7 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil, redisCacheService)
 
         every { validDayOfWeekAndHourUtil.validateApply() } throws NotSelfStudyApplyDayException()
         `when`("신청할 수 없는 요일일때") {
@@ -84,7 +86,7 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil, redisCacheService)
 
         every { validDayOfWeekAndHourUtil.validateApply() } throws NotSelfStudyApplyHourException()
         `when`("신청할 수 없는 시간알때") {
@@ -94,7 +96,7 @@ class ApplySelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, saveSelfStudyUtil, redisCacheService)
 
         every { selfStudyCheckUtil.isSelfStudyStatusCan(testMember) } throws AlreadyApplySelfStudyException()
         `when`("이미 신청한 유저일때") {
@@ -114,11 +116,14 @@ private fun init(
     findSelfStudyCountUtil: FindSelfStudyCountUtil,
     selfStudyCount: SelfStudyCount,
     selfStudyCheckUtil: SelfStudyCheckUtil,
-    saveSelfStudyUtil: SaveSelfStudyUtil
+    saveSelfStudyUtil: SaveSelfStudyUtil,
+    redisCacheService: RedisCacheService
 ) {
     every { validDayOfWeekAndHourUtil.validateApply() } returns Unit
     every { userUtil.fetchCurrentUser() } returns testMember
     every { findSelfStudyCountUtil.findSelfStudyCount() } returns selfStudyCount
     every { selfStudyCheckUtil.isSelfStudyStatusCan(testMember) } returns Unit
     every { saveSelfStudyUtil.save(testMember) } returns Unit
+    every { redisCacheService.getFromCache(any()) } returns Unit
+    every { redisCacheService.putToCache(any(), any()) } answers { nothing }
 }

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/BanSelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/BanSelfStudyServiceTest.kt
@@ -37,6 +37,7 @@ class BanSelfStudyServiceTest : BehaviorSpec({
             profileImage = null
         )
 
+        init(testMember, memberRepository, redisCacheService)
         every { memberRepository.findByIdOrNull(testMember.id) } returns testMember
         `when`("서비스를 실행할때") {
             banSelfStudyServiceImpl.execute(testMember.id)
@@ -48,6 +49,7 @@ class BanSelfStudyServiceTest : BehaviorSpec({
             }
         }
 
+        init(testMember, memberRepository, redisCacheService)
         every { memberRepository.findByIdOrNull(testMember.id) } returns null
         `when`("해당 유저가 없다면") {
             then("MemberNotFoundException이 발생해야함") {
@@ -58,3 +60,13 @@ class BanSelfStudyServiceTest : BehaviorSpec({
         }
     }
 })
+
+private fun init(
+    testMember: Member,
+    memberRepository: MemberRepository,
+    redisCacheService: RedisCacheService
+) {
+    every { memberRepository.findByIdOrNull(testMember.id) } returns testMember
+    every { redisCacheService.getFromCache(any()) } returns Unit
+    every { redisCacheService.putToCache(any(), any()) } answers { nothing }
+}

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/BanSelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/BanSelfStudyServiceTest.kt
@@ -7,6 +7,7 @@ import com.dotori.v2.domain.member.enums.Role
 import com.dotori.v2.domain.member.enums.SelfStudyStatus
 import com.dotori.v2.domain.member.exception.MemberNotFoundException
 import com.dotori.v2.domain.selfstudy.service.impl.BanSelfStudyServiceImpl
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -17,7 +18,13 @@ import java.time.LocalDate
 
 class BanSelfStudyServiceTest : BehaviorSpec({
     val memberRepository = mockk<MemberRepository>()
-    val banSelfStudyServiceImpl = BanSelfStudyServiceImpl(memberRepository)
+    val redisCacheService = mockk<RedisCacheService>()
+
+    val banSelfStudyServiceImpl = BanSelfStudyServiceImpl(
+        memberRepository,
+        redisCacheService
+    )
+
     given("유저가 주어지고") {
         val testMember = Member(
             memberName = "test",

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/CancelSelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/CancelSelfStudyServiceTest.kt
@@ -51,7 +51,7 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
             profileImage = null
         )
         val selfStudyCount = SelfStudyCount(id = 1, count = 1)
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository, redisCacheService)
         `when`("서비스를 실행하면") {
             serviceImpl.execute()
             then("delete 쿼리가 날라가야함") {
@@ -73,7 +73,7 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository, redisCacheService)
 
         every { validDayOfWeekAndHourUtil.validateCancel() } throws NotSelfStudyCancelHourException()
         `when`("취소를 할 수 없는 시간일때") {
@@ -83,7 +83,7 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository, redisCacheService)
 
         every { selfStudyCheckUtil.isSelfStudyStatusApplied(testMember) } throws NotAppliedException()
         `when`("자습에 신청하지 않았을때") {
@@ -93,7 +93,7 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
                 }
             }
         }
-        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository)
+        init(validDayOfWeekAndHourUtil, userUtil, testMember, findSelfStudyCountUtil, selfStudyCount, selfStudyCheckUtil, selfStudyRepository, redisCacheService)
 
 
     }
@@ -106,11 +106,14 @@ private fun init(
     findSelfStudyCountUtil: FindSelfStudyCountUtil,
     selfStudyCount: SelfStudyCount,
     selfStudyCheckUtil: SelfStudyCheckUtil,
-    selfStudyRepository: SelfStudyRepository
+    selfStudyRepository: SelfStudyRepository,
+    redisCacheService: RedisCacheService
 ) {
     every { validDayOfWeekAndHourUtil.validateCancel() } returns Unit
     every { userUtil.fetchCurrentUser() } returns testMember
     every { findSelfStudyCountUtil.findSelfStudyCount() } returns selfStudyCount
     every { selfStudyCheckUtil.isSelfStudyStatusApplied(testMember) } returns Unit
     every { selfStudyRepository.deleteByMember(testMember) } returns Unit
+    every { redisCacheService.getFromCache(any()) } returns Unit
+    every { redisCacheService.putToCache(any(), any()) } answers { nothing }
 }

--- a/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/CancelSelfStudyServiceTest.kt
+++ b/src/test/kotlin/com/dotori/v2/domain/selfstudy/service/CancelSelfStudyServiceTest.kt
@@ -13,6 +13,7 @@ import com.dotori.v2.domain.selfstudy.service.impl.CancelSelfStudyServiceImpl
 import com.dotori.v2.domain.selfstudy.util.FindSelfStudyCountUtil
 import com.dotori.v2.domain.selfstudy.util.SelfStudyCheckUtil
 import com.dotori.v2.domain.selfstudy.util.ValidDayOfWeekAndHourUtil
+import com.dotori.v2.global.config.redis.service.RedisCacheService
 import com.dotori.v2.global.util.UserUtil
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -28,12 +29,15 @@ class CancelSelfStudyServiceTest : BehaviorSpec({
     val validDayOfWeekAndHourUtil = mockk<ValidDayOfWeekAndHourUtil>()
     val selfStudyRepository = mockk<SelfStudyRepository>()
     val selfStudyCheckUtil = mockk<SelfStudyCheckUtil>()
+    val redisCacheService = mockk<RedisCacheService>()
+
     val serviceImpl = CancelSelfStudyServiceImpl(
         userUtil,
         validDayOfWeekAndHourUtil,
         findSelfStudyCountUtil,
         selfStudyRepository,
-        selfStudyCheckUtil
+        selfStudyCheckUtil,
+        redisCacheService
     )
     given("유저가 주어지고") {
         val testMember = Member(


### PR DESCRIPTION
💡 개요
- 회원가입/탈퇴, 유저 프로필 설정, 자습 관련 코드에 캐시 관련 기능 및 캐시 데이터의 TTL 설정을 추가했습니다.

📃 작업내용
- 회원가입/탈퇴, 유저 프로필 설정, 자습 관련 코드가 실행될 때 기존에 memberList 캐시 데이터를 저장 중이라면 해당 데이터를 걷어내는 기능을 구현했습니다.

- memberList 캐시 데이터의 TTL을 1시간으로 설정하는 코드를 추가했습니다.