### PR TITLE
451 hotfix 음악 삭제 스케쥴 플로우 조정

### DIFF
--- a/src/main/kotlin/com/dotori/v2/domain/music/domain/repository/MusicLikeRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/domain/repository/MusicLikeRepository.kt
@@ -14,5 +14,7 @@ interface MusicLikeRepository : JpaRepository<MusicLike,Long> {
 
     fun deleteAllByMusicId(music: Long)
 
+    fun deleteAllByMusicIdIn(musicIds: List<Long>)
+
     fun existsByMusicIdAndMemberId(musicId: Long, memberId: Long): Boolean
 }

--- a/src/main/kotlin/com/dotori/v2/domain/music/domain/repository/MusicRepository.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/domain/repository/MusicRepository.kt
@@ -18,6 +18,8 @@ interface MusicRepository : JpaRepository<Music, Long> {
 
     fun deleteAllByCreatedDateBefore(date: LocalDateTime)
 
+    fun findAllByCreatedDateBefore(date: LocalDateTime): List<Music>
+
     @Query(value = "select * from music where created_date like :date% order by music.like_count desc", nativeQuery = true)
     fun findAllByCreatedDateOrderByLikeCountDESC(@Param("date") date: LocalDate): List<Music>
 }

--- a/src/main/kotlin/com/dotori/v2/domain/music/schedule/MusicSchedule.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/schedule/MusicSchedule.kt
@@ -1,5 +1,6 @@
 package com.dotori.v2.domain.music.schedule
 
+import com.dotori.v2.domain.music.domain.repository.MusicLikeRepository
 import com.dotori.v2.domain.music.domain.repository.MusicRepository
 import com.dotori.v2.global.config.redis.service.RedisCacheService
 import org.slf4j.LoggerFactory
@@ -15,6 +16,7 @@ import java.time.temporal.ChronoUnit
 @Transactional
 class MusicSchedule(
     private val musicRepository: MusicRepository,
+    private val musicLikeRepository: MusicLikeRepository
     private val redisCacheService: RedisCacheService
 ) {
     private val log = LoggerFactory.getLogger(this.javaClass.simpleName)
@@ -27,7 +29,9 @@ class MusicSchedule(
     @Scheduled(cron = "0 0 0 1 * ?")
     fun initMusic() {
         val localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MONTHS)
-        musicRepository.deleteAllByCreatedDateBefore(localDateTime)
+        val musics = musicRepository.findAllByCreatedDateBefore(localDateTime)
+        musicLikeRepository.deleteAllByMusicIdIn(musics.map { it.id })
+        musicRepository.deleteAllInBatch(musics)
         redisCacheService.initCache("musicList:*")
         log.info("delete music data schedule")
     }

--- a/src/main/kotlin/com/dotori/v2/domain/music/schedule/MusicSchedule.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/schedule/MusicSchedule.kt
@@ -16,7 +16,7 @@ import java.time.temporal.ChronoUnit
 @Transactional
 class MusicSchedule(
     private val musicRepository: MusicRepository,
-    private val musicLikeRepository: MusicLikeRepository
+    private val musicLikeRepository: MusicLikeRepository,
     private val redisCacheService: RedisCacheService
 ) {
     private val log = LoggerFactory.getLogger(this.javaClass.simpleName)


### PR DESCRIPTION
💡 개요
2달에 한번씩 음악 데이터를 삭제하는 플로우를 조정했습니다.

📃 작업내용
아래와 같은 flow로 진행됩니다.
- 2달전 음악을 불러온다.
- 해당 음악에 속한 좋아요 정보들을 모두 삭제한다.
- 불러온 음악을 모두 삭제한다.
