### PR TITLE
SQS Event Publish Retry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(Dependencies.VALIDATION)
     implementation(Dependencies.WEB)
     implementation(Dependencies.SPRING_CLOUD)
+    implementation(Dependencies.RETRY)
 
     // kotlin
     implementation(Dependencies.KOTLIN_JACKSON)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,6 +12,7 @@ object Dependencies {
     const val ACTUATOR = "org.springframework.boot:spring-boot-starter-actuator"
     const val PROMETHEUS = "io.micrometer:micrometer-registry-prometheus"
     const val LOKI = "com.github.loki4j:loki-logback-appender:${DependencyVersions.LOKI}"
+    const val RETRY = "org.springframework.retry:spring-retry"
 
     // kotlin
     const val KOTLIN_JACKSON = "com.fasterxml.jackson.module:jackson-module-kotlin"

--- a/src/main/kotlin/com/dotori/v2/domain/music/listener/MusicApplicationEventListener.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/music/listener/MusicApplicationEventListener.kt
@@ -2,20 +2,36 @@ package com.dotori.v2.domain.music.listener
 
 import com.dotori.v2.global.publisher.EventPublisher
 import com.dotori.v2.global.squirrel.MusicDotoriEvent
+import org.slf4j.LoggerFactory
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
+import java.io.IOException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeoutException
 
 @Component
 class MusicApplicationEventListener(
     private val eventPublisher: EventPublisher
 ) {
 
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
+
     @Async("squirrelTaskExecutor")
+    @Retryable(
+        value = [IOException::class, TimeoutException::class, Exception::class],
+        maxAttempts = 3,
+        backoff = Backoff(delay = 2000, multiplier = 2.0)
+    )
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
     fun onEvent(event: MusicDotoriEvent) {
-        eventPublisher.publishEvent(event, event.eventType.toString())
+        log.info("published music event: {} eventType: {}", event.id, event.eventType)
+        CompletableFuture.runAsync {
+            eventPublisher.publishEvent(event,event.eventType.toString())
+        }
     }
 
 }

--- a/src/main/kotlin/com/dotori/v2/domain/reserve/ReserveEventListener.kt
+++ b/src/main/kotlin/com/dotori/v2/domain/reserve/ReserveEventListener.kt
@@ -2,19 +2,37 @@ package com.dotori.v2.domain.reserve
 
 import com.dotori.v2.global.publisher.EventPublisher
 import com.dotori.v2.global.squirrel.ReserveDotoriEvent
+import org.slf4j.LoggerFactory
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
+import java.io.IOException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeoutException
 
 @Component
 class ReserveEventListener(
     private val eventPublisher: EventPublisher
 ) {
 
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
+
     @Async("squirrelTaskExecutor")
+    @Retryable(
+        value = [IOException::class, TimeoutException::class],
+        maxAttempts = 3,
+        backoff = Backoff(delay = 2000, multiplier = 2.0)
+    )
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
     fun onEvent(event: ReserveDotoriEvent) {
-        eventPublisher.publishEvent(event, event.eventType.toString())
+        log.info("published reserve event: {} eventType: {}", event.id, event.eventType)
+        CompletableFuture.runAsync {
+            eventPublisher.publishEvent(event,event.eventType.toString())
+        }
     }
+
 }
+

--- a/src/main/kotlin/com/dotori/v2/global/async/AsyncConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/async/AsyncConfig.kt
@@ -14,7 +14,7 @@ class AsyncConfig {
         val executor = ThreadPoolTaskExecutor()
         executor.corePoolSize = 8
         executor.maxPoolSize = 16
-        executor.setQueueCapacity(30)
+        executor.queueCapacity = 30
         executor.setThreadNamePrefix("Async-")
         executor.initialize()
         return executor

--- a/src/main/kotlin/com/dotori/v2/global/config/config/ConfigurationPropertiesScanConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/config/ConfigurationPropertiesScanConfig.kt
@@ -1,4 +1,4 @@
-package com.dotori.v2.global.config
+package com.dotori.v2.global.config.config
 
 import com.dotori.v2.global.security.jwt.properties.JwtProperties
 import com.dotori.v2.global.security.jwt.properties.JwtTimeProperties

--- a/src/main/kotlin/com/dotori/v2/global/config/redis/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/redis/RedisCacheConfig.kt
@@ -1,4 +1,4 @@
-package com.dotori.v2.global.config
+package com.dotori.v2.global.config.redis
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator

--- a/src/main/kotlin/com/dotori/v2/global/config/retry/RetryConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/retry/RetryConfig.kt
@@ -1,0 +1,9 @@
+package com.dotori.v2.global.config.retry
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.retry.annotation.EnableRetry
+
+@Configuration
+@EnableRetry
+class RetryConfig {
+}

--- a/src/main/kotlin/com/dotori/v2/global/config/schedule/EnableSchedulingConfig.kt
+++ b/src/main/kotlin/com/dotori/v2/global/config/schedule/EnableSchedulingConfig.kt
@@ -1,4 +1,4 @@
-package com.dotori.v2.global.config
+package com.dotori.v2.global.config.schedule
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling

--- a/src/main/kotlin/com/dotori/v2/global/publisher/SQSEventPublisher.kt
+++ b/src/main/kotlin/com/dotori/v2/global/publisher/SQSEventPublisher.kt
@@ -24,5 +24,4 @@ class SQSEventPublisher(
         log.info("publish event {} event-type {}", event, eventType)
         queueMessagingTemplate.send("squirrel-sqs", message)
     }
-
 }


### PR DESCRIPTION
**sqs event를 발행할때 실패하게 되면 3번 2 4 8초 간격으로 재시도합니다.**

dotori내에서 `MessageDuplicationId`를 생성하고 있기 때문에 sourcing할 이벤트는 중복되지 않습니다.
sqs 내의 aws DLQ 구성을 설정해 재시도에서도 실패한 메시지를 처리합니다. 
squirrel sqs는 한대이므로 visibility timeout은 따로 설정하지 않았습니다.